### PR TITLE
Bugfix - cannot pass 'usesubcorp' parameter in widectx action (user clic...

### DIFF
--- a/lib/actions.py
+++ b/lib/actions.py
@@ -38,7 +38,7 @@ class Actions(Kontext):
 
     FREQ_FIGURES = {'docf': 'Document counts', 'frq': 'Word counts', 'arf': 'ARF'}
 
-    WIDECTX_ATTRS = ('usesubcorp', 'attrs', 'attr_allpos', 'ctxattrs', 'structs', 'refs')
+    WIDECTX_ATTRS = ('attrs', 'attr_allpos', 'ctxattrs', 'structs', 'refs')
 
     cattr = Parameter('word')
     csortfn = Parameter('d')


### PR DESCRIPTION
...ks non-primary language => KonText tries to instatiate non-existing subcorpus (wrong lang.))