### PR TITLE
Release 0.6.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+*.*~
+.idea/
+doc/
+log/
+tmp/
+*.db
+*.pyc
+*.xml
+!config.sample.xml
+.directory
+node_modules/
+public/files/js/min/
+public/files/js/compiled/
+public/files/css/kontext.min.css
+lib/plugins/devel_*
+cmpltmpl/*
+!cmpltmpl/__init__.py

--- a/lib/plugins/default_conc_cache.py
+++ b/lib/plugins/default_conc_cache.py
@@ -99,7 +99,13 @@ class CacheMapping(object):
             pidfile = pid_dir + ret + '.pid',
             already_present = True
         else:
-            ret = _uniqname(key, [r for (r, s) in kmap.values()])
+            try:  # TODO - the 'except' is here temporarily to monitor invalid cache map entries
+                ret = _uniqname(key, [r for (r, s) in kmap.values()])
+            except Exception as e:
+                logging.getLogger(__name__).error('Failed to unpack value from cache map: %s, entry: %s' %
+                                                  (e, filter(lambda x: type(x) is not tuple, kmap.values()), ))
+                tmp = map(lambda x: x if type(x) is tuple else (x, 0), kmap.values())
+                ret = _uniqname(key, [r for (r, s) in tmp])
             kmap[subchash, key] = (ret, size)
             f.seek(0)
             cPickle.dump(kmap, f)


### PR DESCRIPTION
We have to monitor the concordance cache map (i.e. the dict which maps queries to respective result files) for a while to find out why an invalid record sometimes occurs.

Also .gitignore has been added to the branch.