### PR TITLE
Improved session ID handling

### DIFF
--- a/lib/actions/user.py
+++ b/lib/actions/user.py
@@ -49,6 +49,7 @@ class User(Kontext):
                                         MainMenu.SAVE, MainMenu.CORPORA, MainMenu.CONCORDANCE,
                                         MainMenu.FILTER, MainMenu.FREQUENCY, MainMenu.COLLOCATIONS)
             self.add_system_message('error', _('Incorrect username or password'))
+        self.refresh_session_id()
         return ans
 
     @exposed(access_level=1, template='user/login.tmpl', skip_corpus_init=True)
@@ -56,8 +57,9 @@ class User(Kontext):
         self.disabled_menu_items = (MainMenu.NEW_QUERY, MainMenu.VIEW,
                                     MainMenu.SAVE, MainMenu.CORPORA, MainMenu.CONCORDANCE,
                                     MainMenu.FILTER, MainMenu.FREQUENCY, MainMenu.COLLOCATIONS)
-        plugins.get('auth').logout(self._session.sid)
+        plugins.get('auth').logout(self._session)
         self._init_session()
+        self.refresh_session_id()
 
         return {
             'message': ('info', _('You have been logged out'))

--- a/lib/plugins/abstract/auth.py
+++ b/lib/plugins/abstract/auth.py
@@ -97,9 +97,9 @@ class AbstractInternalAuth(AbstractAuth):
         """
         raise NotImplementedError()
 
-    def logout(self, session_id):
+    def logout(self, session):
         """
-        Logs-out current user (identified by session_id).
+        Logs-out current user (identified by passed session object).
         """
         raise NotImplementedError()
 
@@ -142,7 +142,7 @@ class AbstractRemoteAuth(AbstractAuth):
     A general authentication based on an external authentication service.
     """
 
-    def revalidate(self, cookies, session, query_string):
+    def revalidate(self, cookies, session, query_string, refresh_sid_fn):
         """
         Re-validates user authentication against external database with central
         authentication ticket (expected to be found in cookies) and session data.
@@ -155,6 +155,7 @@ class AbstractRemoteAuth(AbstractAuth):
         session -- dictionary like session data
         query_string -- the portion of the request URL that follows '?'
         (see environmental variable QUERY_STRING)
+        refresh_sid_fn -- by calling this function KonText will regenerate session ID
         """
         raise NotImplementedError()
 

--- a/lib/plugins/default_auth.py
+++ b/lib/plugins/default_auth.py
@@ -69,12 +69,13 @@ class DefaultAuthHandler(AbstractInternalAuth):
                 }
         return self.anonymous_user()
 
-    def logout(self, session_id):
+    def logout(self, session):
         """
         arguments:
-        session_id -- a session ID
+        session -- Werkzeug session instance
         """
-        self.sessions.delete(session_id)
+        self.sessions.delete(session)
+        session.clear()
 
     def update_user_password(self, user_id, password):
         """

--- a/lib/plugins/default_sessions.py
+++ b/lib/plugins/default_sessions.py
@@ -48,6 +48,8 @@ request processing.
 """
 
 import uuid
+import hashlib
+import random
 
 from werkzeug.contrib.sessions import SessionStore, Session
 
@@ -82,10 +84,10 @@ class DefaultSessions(SessionStore):
             self.db.set_ttl(key, self.ttl)
 
     def generate_key(self, salt=None):
-        return str(uuid.uuid1())
+        return hashlib.sha1(str(uuid.uuid1()) + str(random.random())).hexdigest()
 
-    def delete(self, session_id):
-        self.db.remove(self._mk_key(session_id))
+    def delete(self, session):
+        self.db.remove(self._mk_key(session.sid))
 
     def get(self, sid):
         if not self.is_valid_key(sid):
@@ -99,7 +101,7 @@ class DefaultSessions(SessionStore):
         """
         Writes a new session record to the storage
         """
-        session_id = str(uuid.uuid1())
+        session_id = self.generate_key()
         data = {}
         sess_key = self._mk_key(session_id)
         self.db.set(sess_key, data)

--- a/lib/plugins/ucnk_remote_auth2.py
+++ b/lib/plugins/ucnk_remote_auth2.py
@@ -119,9 +119,10 @@ class CentralAuth(AbstractRemoteAuth):
             ticket_id = None
         return ticket_id
 
-    def revalidate(self, cookies, session, query_string):
+    def revalidate(self, cookies, session, query_string, refresh_sid_fn):
         if 'remote=1' in query_string.split('&'):
             session.clear()
+            refresh_sid_fn()
 
         user_data = session.get('user', {})
         ticket_id = self.get_ticket(cookies)


### PR DESCRIPTION
KonText is now able to regenerate session ID which is used
in default log-in/log-out and optionally in auth plug-in revalidate().