### PR TITLE
Make corparch.search() more flexible and modular

### DIFF
--- a/lib/plugins/abstract/corpora.py
+++ b/lib/plugins/abstract/corpora.py
@@ -138,6 +138,33 @@ class AbstractCorporaArchive(ThreadLocalData):
         raise NotImplementedError()
 
 
+class CorplistProvider(object):
+    """
+    An object providing actual corpus list based on passed arguments.
+    """
+    def search(self, user_id, query, offset=0, limit=None, filter_dict=None):
+        """
+        arguments:
+        user_id -- database user ID
+        query -- raw query entered by user (possibly modified by client-side code)
+        offset -- zero-based offset specifying returned data
+        limit -- number of items to return
+        filter_dict -- a dictionary containing additional search parameters
+        """
+        raise NotImplementedError()
+
+    def sort(self, data, *fields):
+        """
+        arguments:
+        data -- a list of dicts to be sorted
+        *fields -- zero or more keys to be used to sort the data
+
+        returns:
+        sorted original data or their shallow copy
+        """
+        raise NotImplementedError()
+
+
 class AbstractSearchableCorporaArchive(AbstractCorporaArchive):
     """
     An extended version supporting search by user query
@@ -161,6 +188,20 @@ class AbstractSearchableCorporaArchive(AbstractCorporaArchive):
 
         returns:
         a JSON-serializable dictionary a concrete plug-in implementation understands
+        """
+        service = self.create_corplist_provider(plugin_api)
+        return service.search(user_id=user_id, query=query, offset=offset, limit=limit,
+                              filter_dict=filter_dict)
+
+    def create_corplist_provider(self, plugin_api):
+        """
+        A factory function producing search service
+
+        arguments:
+        plugin_api -- a controller.PluginApi instance
+
+        returns:
+        A CorplistProvider instance
         """
         raise NotImplementedError()
 

--- a/lib/plugins/ucnk_corparch.py
+++ b/lib/plugins/ucnk_corparch.py
@@ -83,7 +83,7 @@ import logging
 
 import plugins
 from plugins import inject
-from plugins.default_corparch import CorpusArchive, CorpSearch, parse_query
+from plugins.default_corparch import CorpusArchive, DeafultCorplistProvider, parse_query
 from plugins.abstract.corpora import CorpusInfo
 import l10n
 from controller import exposed
@@ -115,6 +115,15 @@ def ask_corpus_access(controller, request):
     return ans
 
 
+class UcnkCorplistProvider(DeafultCorplistProvider):
+
+    def __init__(self, plugin_api, auth, corparch, tag_prefix):
+        super(UcnkCorplistProvider, self).__init__(plugin_api, auth, corparch, tag_prefix)
+
+    def sort(self, data, *fields):
+        return data
+
+
 class UcnkCorpArch(CorpusArchive):
     """
     Loads and provides access to a hierarchical list of corpora
@@ -139,6 +148,9 @@ class UcnkCorpArch(CorpusArchive):
         ans['initial_keywords'] = plugin_api.session.get(self.SESSION_KEYWORDS_KEY, [self.default_label])
         return ans
 
+    def create_corplist_provider(self, plugin_api):
+        return UcnkCorplistProvider(plugin_api, self._auth, self, self._tag_prefix)
+
     def search(self, plugin_api, user_id, query, offset=0, limit=None, filter_dict=None):
         if self.SESSION_KEYWORDS_KEY not in plugin_api.session:
             plugin_api.session[self.SESSION_KEYWORDS_KEY] = [self.default_label]
@@ -152,9 +164,7 @@ class UcnkCorpArch(CorpusArchive):
             plugin_api.session[self.SESSION_KEYWORDS_KEY] = query_keywords
         query = ' '.join(query_substrs) \
                 + ' ' + ' '.join('%s%s' % (self._tag_prefix, s) for s in query_keywords)
-        search_obj = CorpSearch(plugin_api, self._auth, self, self._tag_prefix)
-        return super(UcnkCorpArch, self).search_via_service(search_obj, user_id, query, offset,
-                                                            limit, filter_dict)
+        return super(UcnkCorpArch, self).search(plugin_api, user_id, query, offset, limit, filter_dict)
 
     def send_request_email(self, corpus_id, user, user_id, custom_message):
         """


### PR DESCRIPTION
Now it is possible to define custom sort() function
via a custom CorplistProvider implementation. The whole
solution should be now more 'readable'.