### PR TITLE
Fix - do not pass 'usesubcorp' arg

### DIFF
--- a/public/files/js/tpl/view.ts
+++ b/public/files/js/tpl/view.ts
@@ -343,6 +343,9 @@ export class ViewPage {
         this.lineViewStore.bindExternalKwicDetailFn((corpusId:string, tokenNum:number, lineIdx:number) => {
             let args = this.layoutModel.getConcArgs().toDict();
             args['corpname'] = corpusId; // just for sure (is should be already in args)
+            // we must delete 'usesubcorp' as the server API does not need it
+            // and in case of an aligned corpus it even produces an error
+            delete args['usesubcorp'];
             args['pos'] = String(tokenNum);
             this.concDetail.showDetail(
                 this.layoutModel.createActionUrl('widectx'),


### PR DESCRIPTION
... it produces an error in case of an aligned corpus