### PR TITLE
Change the way how concordance keys are archived (UCNK only)

### DIFF
--- a/lib/plugins/abstract/general_storage.py
+++ b/lib/plugins/abstract/general_storage.py
@@ -37,13 +37,21 @@ class KeyValueStorage(object):
         """
         raise NotImplementedError()
 
-    def list_push(self, key, value):
+    def list_append(self, key, value):
         """
-        Push a value at the end of a list
+        Add a value at the end of a list
 
         arguments:
         key -- data access key
         value -- value to be pushed
+        """
+        raise NotImplementedError()
+
+    def list_pop(self, key):
+        """
+        Remove and return an element from the
+        beginning of the list.
+
         """
         raise NotImplementedError()
 

--- a/lib/plugins/default_db.py
+++ b/lib/plugins/default_db.py
@@ -79,10 +79,16 @@ class DefaultDb(KeyValueStorage):
             data = data[from_idx:(len(data) + 1 + to_idx)]
         return data
 
-    def list_push(self, key, value):
+    def list_append(self, key, value):
         data = self.list_get(key)
         data.append(value)
         self.set(key, data)
+
+    def list_pop(self, key):
+        data = self.list_get(key)
+        ans = data.pop(0)
+        self.set(key, data)
+        return ans
 
     def list_len(self, key):
         return len(self.list_get(key))

--- a/lib/plugins/default_query_storage.py
+++ b/lib/plugins/default_query_storage.py
@@ -81,7 +81,7 @@ class QueryStorage(AbstractQueryStorage):
             'query_type': query_type,
             'created': self._current_timestamp()
         }
-        self.db.list_push(data_key, item)
+        self.db.list_append(data_key, item)
         if random.random() < QueryStorage.PROB_DELETE_OLD_RECORDS:
             self.delete_old_records(data_key)
 

--- a/lib/plugins/redis_db/__init__.py
+++ b/lib/plugins/redis_db/__init__.py
@@ -70,15 +70,18 @@ class RedisDb(KeyValueStorage):
         """
         return [json.loads(s) for s in self.redis.lrange(key, from_idx, to_idx)]
 
-    def list_push(self, key, value):
+    def list_append(self, key, value):
         """
-        Push a value at the end of a list
+        Add a value at the end of a list
 
         arguments:
         key -- data access key
         value -- value to be pushed
         """
         self.redis.rpush(key, json.dumps(value))
+
+    def list_pop(self, key):
+        return self.redis.lpop(key)
 
     def list_len(self, key):
         """

--- a/lib/plugins/ucnk_conc_persistence2/__init__.py
+++ b/lib/plugins/ucnk_conc_persistence2/__init__.py
@@ -27,6 +27,10 @@ element conc_persistence {
     attribute extension-by { "ucnk" }
     { text } # a path to a sqlite3 database (see SQL below)
   }
+  element archive_queue_key {
+    attribute extension-by { "ucnk" }
+    { text } # a key used in Redis to access the archive processing queue
+  }
 }
 
 archive db:
@@ -147,6 +151,7 @@ class ConcPersistence(AbstractConcPersistence):
         self.ttl = ttl_days * 24 * 3600
         anonymous_user_ttl_days = int(plugin_conf.get('default:anonymous_user_ttl_days', ConcPersistence.DEFAULT_ANONYMOUS_USER_TTL_DAYS))
         self.anonymous_user_ttl = anonymous_user_ttl_days * 24 * 3600
+        self._archive_queue_key = plugin_conf['ucnk:archive_queue_key']
 
         self.db = db
         self._auth = auth
@@ -226,6 +231,8 @@ class ConcPersistence(AbstractConcPersistence):
             data_key = mk_key(data_id)
             self.db.set(data_key, curr_data)
             self.db.set_ttl(data_key, self._get_ttl_for(user_id))
+            if not self._auth.is_anonymous(user_id):
+                self.db.list_append(self._archive_queue_key, dict(key=data_key))
             latest_id = curr_data[ID_KEY]
         else:
             latest_id = prev_data[ID_KEY]
@@ -236,12 +243,9 @@ class ConcPersistence(AbstractConcPersistence):
         """
         Export tasks for Celery worker(s)
         """
-        def archive_concordance(cron_interval, key_prefix, dry_run):
+        def archive_concordance(num_proc, dry_run):
             import archive
-            from plugins.ucnk_conc_persistence2 import KEY_ALPHABET, PERSIST_LEVEL_KEY
-            ans = archive.run(conf=self._settings, key_prefix=key_prefix, cron_interval=cron_interval,
-                              dry_run=dry_run, persist_level_key=PERSIST_LEVEL_KEY, key_alphabet=KEY_ALPHABET)
-            return ans
+            return archive.run(conf=self._settings, num_proc=num_proc, dry_run=dry_run)
         return archive_concordance,
 
     def export_actions(self):

--- a/tests/mocks/storage.py
+++ b/tests/mocks/storage.py
@@ -27,10 +27,13 @@ class TestingKeyValueStorage(KeyValueStorage):
     def list_get(self, key, from_idx=0, to_idx=-1):
         return self._data[key][from_idx:to_idx]
 
-    def list_push(self, key, value):
+    def list_append(self, key, value):
         if key not in self._data:
             self._data[key] = []
         self._data[key].append(value)
+
+    def list_pop(self, key):
+        return self._data[key].pop(0)
 
     def list_len(self, key):
         if key not in self._data:


### PR DESCRIPTION
... now we use a queue stored within Redis where items
are inserted right after a concordance is stored