### PR TITLE
Add missing cursor.close()  (UCNK-specific plug-in)

### DIFF
--- a/lib/plugins/ucnk_remote_auth3/__init__.py
+++ b/lib/plugins/ucnk_remote_auth3/__init__.py
@@ -240,6 +240,7 @@ class CentralAuth(AbstractRemoteAuth):
         else:
             logging.getLogger(__name__).error(
                 'Failed to synchronize corpora for user {0}: empty list. Keeping user\'s current list.'.format(user_id))
+        cursor.close()
         src_db.close()
 
     def get_user_info(self, user_id):


### PR DESCRIPTION
(solves 'Aborted connection' on MySQL server)