### PR TITLE
Fix multiple errors in custom dynamic mm item

### DIFF
--- a/lib/plugins/abstract/menu_items.py
+++ b/lib/plugins/abstract/menu_items.py
@@ -69,7 +69,10 @@ class StaticMenuItem(object):
         return self._data.get('openInBlank', False)
 
     def to_dict(self):
-        return dict(label=self.label, url=self.url, openInBlank=self.open_in_blank)
+        # we export also the 'args' argument even if it is not
+        # used here as it allows the client to recognized the
+        # item as a static one
+        return dict(label=self.label, action=self.url, openInBlank=self.open_in_blank, args={})
 
 
 class AbstractMenuItems(object):

--- a/public/files/js/stores/mainMenu.ts
+++ b/public/files/js/stores/mainMenu.ts
@@ -78,7 +78,7 @@ function isDynamicItem(item:SubmenuItem): item is DynamicSubmenuItem {
  * This defines a TS type guard for StaticSubmenuItem
  */
 function isStaticItem(item:SubmenuItem): item is StaticSubmenuItem {
-    return (<StaticSubmenuItem>item).action !== undefined;
+    return (<StaticSubmenuItem>item).args !== undefined;
 }
 
 function importMenuData(data:InitialMenuData):Immutable.List<MenuEntry> {
@@ -165,7 +165,7 @@ export class MainMenuStore extends SimplePageStore implements Kontext.IMainMenuS
         const srchIdx = this.data.findIndex(item => item[0] === itemId);
         if (srchIdx) {
             const srch = this.data.get(srchIdx);
-            if (subItemId === undefined) {
+            if (subItemId === undefined) { // no submenu specified => we disable whole menu section
                 const newItem:MenuItem = {
                     disabled: v,
                     fallbackAction: srch[1].fallbackAction,

--- a/public/files/js/views/menu.jsx
+++ b/public/files/js/views/menu.jsx
@@ -47,14 +47,17 @@ export function init(dispatcher, he, concArgHandler, mainMenuStore, asyncTaskSto
     const Item = (props) => {
 
         const createLink = () => {
-            if (props.data.url) {
-                return props.data.url;
+            if (props.data.action) {
+                if (props.data.action.indexOf('http://') === 0 ||
+                            props.data.action.indexOf('https://') === 0) {
+                    return props.data.action;
 
-            } else if (props.data.action && typeof props.data.args === 'string') {
-                return he.createActionLink(props.data.action + '?' + props.data.args);
+                } else if (props.data.action && typeof props.data.args === 'string') {
+                    return he.createActionLink(props.data.action + '?' + props.data.args);
 
-            } else if (props.data.action) {
-                return he.createActionLink(props.data.action, props.data.args);
+                } else {
+                    return he.createActionLink(props.data.action, props.data.args);
+                }
             }
             return undefined;
         };


### PR DESCRIPTION
There was a problem with distinguishing some menu
item types within a clumsy type definitions (core one
with action, core one with message, custom dynamic,
custom static).