### PR TITLE
Change auth.permitted_corpora signature

### DIFF
--- a/lib/actions/subcorpus.py
+++ b/lib/actions/subcorpus.py
@@ -231,7 +231,7 @@ class Subcorpus(Querying):
         filter_args = dict(show_deleted=bool(int(request.args.get('show_deleted', 0))),
                            corpname=request.args.get('corpname'))
         data = []
-        user_corpora = plugins.get('auth').permitted_corpora(self._session_get('user', 'id')).values()
+        user_corpora = plugins.get('auth').permitted_corpora(self._session_get('user')).values()
         related_corpora = set()
         for corp in user_corpora:
             try:

--- a/lib/kontext.py
+++ b/lib/kontext.py
@@ -611,7 +611,7 @@ class Kontext(Controller):
         self.args.__dict__.update(na)
 
     def _check_corpus_access(self, path, form, action_metadata):
-        allowed_corpora = plugins.get('auth').permitted_corpora(self._session_get('user', 'id'))
+        allowed_corpora = plugins.get('auth').permitted_corpora(self._session_get('user'))
         if not action_metadata.get('skip_corpus_init', False):
             self.args.corpname, fallback_url = self._determine_curr_corpus(form, allowed_corpora)
             if fallback_url:
@@ -788,7 +788,7 @@ class Kontext(Controller):
         auth = plugins.get('auth')
         if cn not in corp_list and isinstance(auth, plugins.abstract.auth.AbstractRemoteAuth):
             auth.refresh_user_permissions(self._plugin_api)
-            corp_list = auth.permitted_corpora(self._session_get('user', 'id'))
+            corp_list = auth.permitted_corpora(self._session_get('user'))
         # 2) try alternative corpus configuration (e.g. with restricted access)
         # automatic restricted/unrestricted corpus name selection
         # according to user rights
@@ -851,7 +851,7 @@ class Kontext(Controller):
         returns:
         a dict (canonical_id, id)
         """
-        return plugins.get('auth').permitted_corpora(self._session_get('user', 'id'))
+        return plugins.get('auth').permitted_corpora(self._session_get('user'))
 
     def _add_corpus_related_globals(self, result, maincorp):
         """
@@ -1367,6 +1367,10 @@ class PluginApi(object):
     @property
     def user_id(self):
         return self._session.get('user', {'id': None}).get('id')
+
+    @property
+    def user_dict(self):
+        return self._session.get('user', {'id': None})
 
     @property
     def user_is_anonymous(self):

--- a/lib/plugins/abstract/auth.py
+++ b/lib/plugins/abstract/auth.py
@@ -64,12 +64,14 @@ class AbstractAuth(object):
         """
         return corpname
 
-    def permitted_corpora(self, user_id):
+    def permitted_corpora(self, user_dict):
         """
         Return a dictionary containing corpora IDs user can access.
 
         arguments:
-        user_id -- database user ID
+        user_dict -- a user credentials dict containing data returned
+                     by validate_user() (or written by revalidate() in
+                     case of AbstractRemoteAuth).
 
         returns:
         a dict canonical_corpus_id=>corpus_id

--- a/lib/plugins/default_auth.py
+++ b/lib/plugins/default_auth.py
@@ -109,8 +109,8 @@ class DefaultAuthHandler(AbstractInternalAuth):
         """
         return corpname.rsplit('/', 1)[-1]
 
-    def permitted_corpora(self, user_id):
-        corpora = self.db.get(self._mk_list_key(user_id), [])
+    def permitted_corpora(self, user_dict):
+        corpora = self.db.get(self._mk_list_key(user_dict['id']), [])
         if IMPLICIT_CORPUS not in corpora:
             corpora.append(IMPLICIT_CORPUS)
         return dict([(self.canonical_corpname(c), c) for c in corpora])

--- a/lib/plugins/default_corparch/__init__.py
+++ b/lib/plugins/default_corparch/__init__.py
@@ -277,7 +277,7 @@ class DeafultCorplistProvider(CorplistProvider):
         if query is False:  # False means 'use default values'
             query = ''
         ans = {'rows': []}
-        permitted_corpora = self._auth.permitted_corpora(plugin_api.user_id)
+        permitted_corpora = self._auth.permitted_corpora(plugin_api.user_dict)
         used_keywords = set()
         all_keywords_map = dict(self._corparch.all_keywords(plugin_api.user_lang))
         if filter_dict.get('minSize'):
@@ -672,8 +672,7 @@ class CorpusArchive(AbstractSearchableCorporaArchive):
             return u'{0} [{1}]'.format(text, _('translation not available'))
 
     def _export_featured(self, plugin_api):
-        user_id = plugin_api.user_id
-        permitted_corpora = self._auth.permitted_corpora(user_id)
+        permitted_corpora = self._auth.permitted_corpora(plugin_api.user_dict)
 
         def is_featured(o):
             return o['metadata'].get('featured', False)

--- a/lib/plugins/lindat_auth/__init__.py
+++ b/lib/plugins/lindat_auth/__init__.py
@@ -123,7 +123,7 @@ class LINDATAuth(AbstractSemiInternalAuth):
         self.sessions.delete(session)
         session.clear()
 
-    def permitted_corpora(self, user_id):
+    def permitted_corpora(self, user_dict):
         return self.corplist
 
     def is_administrator(self, user_id):

--- a/lib/plugins/ucnk_remote_auth2/__init__.py
+++ b/lib/plugins/ucnk_remote_auth2/__init__.py
@@ -208,17 +208,17 @@ class CentralAuth(AbstractRemoteAuth):
     def canonical_corpname(self, corpname):
         return corpname.rsplit('/', 1)[-1]
 
-    def permitted_corpora(self, user_id):
+    def permitted_corpora(self, user_dict):
         """
         Fetches list of corpora available to the current user
 
         arguments:
-        user_id -- a database user ID
+        user_dict -- a user credentials dictionary
 
         returns:
         a dict (canonical_corp_name, corp_name)
         """
-        corpora = self._db.get(self._mk_list_key(user_id), [])
+        corpora = self._db.get(self._mk_list_key(user_dict['id']), [])
         if IMPLICIT_CORPUS not in corpora:
             corpora.append(IMPLICIT_CORPUS)
         return dict([(self.canonical_corpname(c), c) for c in corpora])

--- a/lib/plugins/ucnk_remote_auth3/__init__.py
+++ b/lib/plugins/ucnk_remote_auth3/__init__.py
@@ -212,17 +212,17 @@ class CentralAuth(AbstractRemoteAuth):
     def canonical_corpname(self, corpname):
         return corpname.rsplit('/', 1)[-1]
 
-    def permitted_corpora(self, user_id):
+    def permitted_corpora(self, user_dict):
         """
         Fetches list of corpora available to the current user
 
         arguments:
-        user_id -- a database user ID
+        user_dict -- a user credentials dictionary
 
         returns:
         a dict (canonical_corp_name, corp_name)
         """
-        corpora = self._db.get(self._mk_list_key(user_id), [])
+        corpora = self._db.get(self._mk_list_key(user_dict['id']), [])
         if IMPLICIT_CORPUS not in corpora:
             corpora.append(IMPLICIT_CORPUS)
         return dict([(self.canonical_corpname(c), c) for c in corpora])


### PR DESCRIPTION
Now, instead of user_id we pass whole user_dict credentials
dictionary to allow more general behavior