### PR TITLE
Change auth.permitted_corpora signature

### DIFF
--- a/lib/actions/subcorpus.py
+++ b/lib/actions/subcorpus.py
@@ -231,7 +231,7 @@ class Subcorpus(Querying):
         filter_args = dict(show_deleted=bool(int(request.args.get('show_deleted', 0))),
                            corpname=request.args.get('corpname'))
         data = []
-        user_corpora = plugins.runtime.AUTH.instance.permitted_corpora(self.session_get('user', 'id')).values()
+        user_corpora = plugins.runtime.AUTH.instance.permitted_corpora(self.session_get('user')).values()
         related_corpora = set()
         for corp in user_corpora:
             try:

--- a/lib/kontext.py
+++ b/lib/kontext.py
@@ -633,8 +633,7 @@ class Kontext(Controller):
         self.args.__dict__.update(na)
 
     def _check_corpus_access(self, path, form, action_metadata):
-        allowed_corpora = plugins.runtime.AUTH.instance.permitted_corpora(
-            self.session_get('user', 'id'))
+        allowed_corpora = plugins.runtime.AUTH.instance.permitted_corpora(self.session_get('user'))
         if not action_metadata.get('skip_corpus_init', False):
             self.args.corpname, fallback_url = self._determine_curr_corpus(form, allowed_corpora)
             if fallback_url:
@@ -808,7 +807,7 @@ class Kontext(Controller):
         with plugins.runtime.AUTH as auth:
             if cn not in corp_list and isinstance(auth, AbstractRemoteAuth):
                 auth.refresh_user_permissions(self._plugin_api)
-                corp_list = auth.permitted_corpora(self.session_get('user', 'id'))
+                corp_list = auth.permitted_corpora(self.session_get('user'))
         # 2) try alternative corpus configuration (e.g. with restricted access)
         # automatic restricted/unrestricted corpus name selection
         # according to user rights
@@ -873,7 +872,7 @@ class Kontext(Controller):
         returns:
         a dict (canonical_id, id)
         """
-        return plugins.runtime.AUTH.instance.permitted_corpora(self.session_get('user', 'id'))
+        return plugins.runtime.AUTH.instance.permitted_corpora(self.session_get('user'))
 
     def _add_corpus_related_globals(self, result, maincorp):
         """
@@ -1391,6 +1390,10 @@ class PluginApi(object):
     @property
     def user_id(self):
         return self._session.get('user', {'id': None}).get('id')
+
+    @property
+    def user_dict(self):
+        return self._session.get('user', {'id': None})
 
     @property
     def user_is_anonymous(self):

--- a/lib/kontext.pyi
+++ b/lib/kontext.pyi
@@ -145,6 +145,9 @@ class PluginApi(object):
     def user_id(self) -> int: ...
 
     @property
+    def user_dict(self) -> Dict[str, Any]: ...
+
+    @property
     def user_is_anonymous(self) -> bool: ...
 
     @property

--- a/lib/plugins/abstract/auth.py
+++ b/lib/plugins/abstract/auth.py
@@ -64,12 +64,14 @@ class AbstractAuth(object):
         """
         return corpname
 
-    def permitted_corpora(self, user_id):
+    def permitted_corpora(self, user_dict):
         """
         Return a dictionary containing corpora IDs user can access.
 
         arguments:
-        user_id -- database user ID
+        user_dict -- user credentials as returned by validate_user()
+                     (or as written to session by revalidate() in case
+                     of AbstractRemoteAuth implementations).
 
         returns:
         a dict canonical_corpus_id=>corpus_id
@@ -105,7 +107,7 @@ class AbstractSemiInternalAuth(AbstractAuth):
         username -- login username
         password -- login password
 
-        returns
+        returns:
         a dict {'id': ..., 'user': ..., 'fullname'} where 'user' means
         actually 'username'.
         """
@@ -177,6 +179,9 @@ class AbstractRemoteAuth(AbstractAuth):
 
         Please note that in case this method raises an exception, KonText
         automatically sets current user as 'anonymous' to prevent security issues.
+
+        The method is expected to write a proper user credentials dict to
+        the session. Please see AbstractSemiInternalAuth.validate_user for details.
 
         arguments:
         plugin_api -- a controller.PluginApi instance

--- a/lib/plugins/default_auth/__init__.py
+++ b/lib/plugins/default_auth/__init__.py
@@ -112,8 +112,8 @@ class DefaultAuthHandler(AbstractInternalAuth):
         """
         return corpname.rsplit('/', 1)[-1]
 
-    def permitted_corpora(self, user_id):
-        corpora = self.db.get(self._mk_list_key(user_id), [])
+    def permitted_corpora(self, user_dict):
+        corpora = self.db.get(self._mk_list_key(user_dict['id']), [])
         if IMPLICIT_CORPUS not in corpora:
             corpora.append(IMPLICIT_CORPUS)
         return dict([(self.canonical_corpname(c), c) for c in corpora])

--- a/lib/plugins/default_corparch/__init__.py
+++ b/lib/plugins/default_corparch/__init__.py
@@ -276,7 +276,7 @@ class DeafultCorplistProvider(CorplistProvider):
         if query is False:  # False means 'use default values'
             query = ''
         ans = {'rows': []}
-        permitted_corpora = self._auth.permitted_corpora(plugin_api.user_id)
+        permitted_corpora = self._auth.permitted_corpora(plugin_api.user_dict)
         used_keywords = set()
         all_keywords_map = dict(self._corparch.all_keywords(plugin_api.user_lang))
         if filter_dict.get('minSize'):
@@ -672,8 +672,7 @@ class CorpusArchive(AbstractSearchableCorporaArchive):
             return u'{0} [{1}]'.format(text, _('translation not available'))
 
     def _export_featured(self, plugin_api):
-        user_id = plugin_api.user_id
-        permitted_corpora = self._auth.permitted_corpora(user_id)
+        permitted_corpora = self._auth.permitted_corpora(plugin_api.user_dict)
 
         def is_featured(o):
             return o['metadata'].get('featured', False)

--- a/lib/plugins/lindat_auth/__init__.py
+++ b/lib/plugins/lindat_auth/__init__.py
@@ -123,7 +123,7 @@ class LINDATAuth(AbstractSemiInternalAuth):
         self.sessions.delete(session)
         session.clear()
 
-    def permitted_corpora(self, user_id):
+    def permitted_corpora(self, user_dict):
         return self.corplist
 
     def is_administrator(self, user_id):

--- a/lib/plugins/ucnk_remote_auth2/__init__.py
+++ b/lib/plugins/ucnk_remote_auth2/__init__.py
@@ -209,7 +209,7 @@ class CentralAuth(AbstractRemoteAuth):
     def canonical_corpname(self, corpname):
         return corpname.rsplit('/', 1)[-1]
 
-    def permitted_corpora(self, user_id):
+    def permitted_corpora(self, user_dict):
         """
         Fetches list of corpora available to the current user
 
@@ -219,7 +219,7 @@ class CentralAuth(AbstractRemoteAuth):
         returns:
         a dict (canonical_corp_name, corp_name)
         """
-        corpora = self._db.get(self._mk_list_key(user_id), [])
+        corpora = self._db.get(self._mk_list_key(user_dict['id']), [])
         if IMPLICIT_CORPUS not in corpora:
             corpora.append(IMPLICIT_CORPUS)
         return dict([(self.canonical_corpname(c), c) for c in corpora])

--- a/lib/plugins/ucnk_remote_auth3/__init__.py
+++ b/lib/plugins/ucnk_remote_auth3/__init__.py
@@ -213,17 +213,17 @@ class CentralAuth(AbstractRemoteAuth):
     def canonical_corpname(self, corpname):
         return corpname.rsplit('/', 1)[-1]
 
-    def permitted_corpora(self, user_id):
+    def permitted_corpora(self, user_dict):
         """
         Fetches list of corpora available to the current user
 
         arguments:
-        user_id -- a database user ID
+        user_dict -- a user credentials dictionary
 
         returns:
         a dict (canonical_corp_name, corp_name)
         """
-        corpora = self._db.get(self._mk_list_key(user_id), [])
+        corpora = self._db.get(self._mk_list_key(user_dict['id']), [])
         if IMPLICIT_CORPUS not in corpora:
             corpora.append(IMPLICIT_CORPUS)
         return dict([(self.canonical_corpname(c), c) for c in corpora])

--- a/tests/mocks/mplugins.py
+++ b/tests/mocks/mplugins.py
@@ -63,7 +63,7 @@ class MockAuth(AbstractAuth):
     def canonical_corpname(self, corpname):
         return corpname
 
-    def permitted_corpora(self, user_id):
+    def permitted_corpora(self, user_dict):
         raise NotImplementedError()
 
     def get_user_info(self, user_id):


### PR DESCRIPTION
Now, instead of user_id we pass whole user_dict credentials
dictionary to allow more general behavior