### PR TITLE
Fix rendering of the 'kwic without kwic'

### DIFF
--- a/public/files/js/views/concordance/lines.jsx
+++ b/public/files/js/views/concordance/lines.jsx
@@ -219,7 +219,7 @@ export function init(dispatcher, he, lineStore, lineSelectionStore, concDetailSt
                 ans.push('<--not translated-->');
 
             } else {
-                ans.push(<span key={`k:${i}`}>{item.text.join(' ')} </span>);
+                ans.push(<span key={`k:${i}`} className={item.className === 'strc' ? 'strc' : null}>{item.text.join(' ')} </span>);
             }
             return ans;
         }


### PR DESCRIPTION
(in case of aligned corpora, when there is an empty query
on the aligned side, Manatee returns matching text as kwic one
even if there is actually no kwic there)