### PR TITLE
Add new methods to db plugins 

### DIFF
--- a/lib/plugins/abstract/general_storage.py
+++ b/lib/plugins/abstract/general_storage.py
@@ -217,3 +217,10 @@ class KeyValueStorage(object):
         never called).
         """
         raise NotImplementedError()
+
+    def get_instance(self, plugin_id):
+        """
+        Return the current instance of the plug-in
+        """
+        return self
+

--- a/lib/plugins/redis_db/__init__.py
+++ b/lib/plugins/redis_db/__init__.py
@@ -275,9 +275,10 @@ class RedisDb(KeyValueStorage):
         key and value from the 'mapping' dict.
         Before setting, the values are json-serialized
         """
+        new_mapping = {}
         for name in mapping:
-            mapping[name] = json.dumps(mapping[name])
-        return self.redis.hmset(key, mapping)
+            new_mapping[name] = json.dumps(mapping[name])
+        return self.redis.hmset(key, new_mapping)
 
 
 def create_instance(conf):

--- a/lib/plugins/redis_db/__init__.py
+++ b/lib/plugins/redis_db/__init__.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2017 Charles University, Faculty of Arts,
 #                    Institute of the Czech National Corpus
 # Copyright (c) 2017 Tomas Machalek <tomas.machalek@gmail.com>
+# Copyright (c) 2017 Petr Duda <petrduda@seznam.cz>
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -42,9 +43,7 @@ element db {
 """
 
 import json
-
 import redis
-
 from plugins.abstract.general_storage import KeyValueStorage
 
 
@@ -262,6 +261,23 @@ class RedisDb(KeyValueStorage):
         previous key if any or None
         """
         return self.redis.getset(key, value)
+
+    def incr(self, key, amount=1):
+        """
+        Increments the value of 'key' by 'amount'.  If no key exists,
+        the value will be initialized as 'amount'
+        """
+        return self.redis.incr(key, amount)
+
+    def hash_set_map(self, key, mapping):
+        """
+        Set key to value within hash 'name' for each corresponding
+        key and value from the 'mapping' dict.
+        Before setting, the values are json-serialized
+        """
+        for name in mapping:
+            mapping[name] = json.dumps(mapping[name])
+        return self.redis.hmset(key, mapping)
 
 
 def create_instance(conf):

--- a/lib/plugins/sqlite3_db/__init__.py
+++ b/lib/plugins/sqlite3_db/__init__.py
@@ -270,6 +270,26 @@ class DefaultDb(KeyValueStorage):
             self._conn().commit()
         return None
 
+    def incr(self, key, amount=1):
+        """
+        Increments the value of 'key' by 'amount'.  If no key exists,
+        the value will be initialized as 'amount'
+        """
+        val = self.get(key)
+        if val is None:
+            val = 0
+        val += amount
+        self.set(key, val)
+        return val
+
+    def hash_set_map(self, key, mapping):
+        """
+        Set key to value within hash 'name' for each corresponding
+        key and value from the 'mapping' dict.
+        """
+        self.set(key, mapping)
+        return True
+
 
 def create_instance(conf):
     """

--- a/tests/plugins_tests/test_dbplugins.py
+++ b/tests/plugins_tests/test_dbplugins.py
@@ -29,6 +29,7 @@ import sqlite3
 import time
 from plugins.redis_db import RedisDb
 from plugins.sqlite3_db import DefaultDb
+from plugins.abstract.general_storage import KeyValueStorage
 
 # set test parameters
 TEST_TTL_METHODS = True  # set to False to speed up by skipping ttl testing which involves time.sleep()
@@ -442,6 +443,35 @@ class DbTest(unittest.TestCase):
         out_s = s1.get(key)
         self.assertEqual(out_r, out_s)
 
+    def test_incr(self):
+        """
+        Test the incr method:
+        Set key1 to an integer value, do not set the other key
+        Increase both keys by an amount, check correct values (the not-yet-set key2 should amount to 0 + amount)
+        """
+        key1 = 'key1'
+        key2 = 'key2'
+        number1 = 100
+        amount = 10
+        self.r.set(key1, number1)
+        self.r.incr(key1, amount)
+        self.r.incr(key2, amount)
+        self.assertEqual(self.r.get(key1), number1+amount)
+        self.assertEqual(self.r.get(key2), amount)
+
+    def test_hash_set_map(self):
+        d = {'val1': 100, 'val2': 'times'}
+        self.r.hash_set_map('hash1', d)
+        out_r = str(self.r.hash_get('hash1', 'val1')) + self.r.hash_get('hash1', 'val2')
+        self.assertEqual(out_r, "100times")
+
+    def test_get_instance(self):
+        """
+        test the get_instance, which is defined in the KeyValueStorage abstract class
+
+        """
+        self.assertTrue(isinstance(self.r.get_instance(1), KeyValueStorage))
+        self.assertTrue(isinstance(self.s.get_instance(1), KeyValueStorage))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Add three new methods (hash_set_map, incr and create_instance) to both db plugins and to db unittests
