### PR TITLE
Improve action logging configurability/extensibility

### DIFF
--- a/conf/config.rng
+++ b/conf/config.rng
@@ -53,6 +53,15 @@
         </zeroOrMore>
     </define>
 
+    <define name="boolValues">
+        <choice>
+            <value>false</value>
+            <value>true</value>
+            <value>0</value>
+            <value>1</value>
+        </choice>
+    </define>
+
     <start>
         <element name="kontext">
             <optional>
@@ -156,12 +165,7 @@
                                 be able to watch for the element as a sign that the application
                                 is completely ready.
                             </a:documentation>
-                            <choice>
-                                <value>0</value>
-                                <value>1</value>
-                                <value>false</value>
-                                <value>true</value>
-                            </choice>
+                            <ref name="boolValues" />
                         </element>
                     </optional>
                     <optional>
@@ -175,12 +179,7 @@
                         <a:documentation>Switches KonText into a special mode when only a static page
                         is presented to a user and all the plug-in dependencies are disabled (i.e.
                         it should work even if KonText components are down).</a:documentation>
-                        <choice>
-                            <value>0</value>
-                            <value>1</value>
-                            <value>false</value>
-                            <value>true</value>
-                        </choice>
+                        <ref name="boolValues" />
                     </element>
                     <element name="max_attr_list_size">
                         <a:documentation>Defines a maximum number of items in the checkbox table
@@ -258,21 +257,11 @@
                     <element name="use_conc_toolbar">
                         <a:documentation>If true then a special toolbar allowing easier setting of
                         common concordance view options is shown</a:documentation>
-                        <choice>
-                            <value>0</value>
-                            <value>1</value>
-                            <value>false</value>
-                            <value>true</value>
-                        </choice>
+                        <ref name="boolValues" />
                     </element>
                     <element name="anonymous_user_conc_login_prompt">
                         <a:documentation>If true then for anonymous user, on concordance page a prompt to log-in always appears</a:documentation>
-                        <choice>
-                            <value>0</value>
-                            <value>1</value>
-                            <value>false</value>
-                            <value>true</value>
-                        </choice>
+                        <ref name="boolValues" />
                     </element>
                     <optional>
                         <element name="shuffle_min_result_warning">
@@ -283,12 +272,7 @@
                     </optional>
                     <optional>
                         <element name="shuffle_conc_by_default">
-                            <choice>
-                                <value>0</value>
-                                <value>1</value>
-                                <value>false</value>
-                                <value>true</value>
-                            </choice>
+                            <ref name="boolValues" />
                             <a:documentation>If true then concordance will be shuffled by default (user can change
                             this in his/her settings). By default this is set to false.
                             </a:documentation>
@@ -305,12 +289,7 @@
                     </optional>
                     <optional>
                         <element name="explicit_conc_persistence_ui">
-                            <choice>
-                                <value>0</value>
-                                <value>1</value>
-                                <value>false</value>
-                                <value>true</value>
-                            </choice>
+                            <ref name="boolValues" />
                             <a:documentation>If true then KonText shows menu item and a button providing a
                                 function -make concordance link persistent-. This is linked
                                 to the conc_persistence.archive() function.
@@ -356,6 +335,14 @@
                             </element>
                         </zeroOrMore>
                     </element>
+                    <optional>
+                        <element name="skip_user_actions">
+                            <a:documentation>If true than all the user action will be skipped in log which basically
+                            means that mostly warnings and errors will be logged. This is useful in case you want
+                            to log user requests in a custom way via dispatch_hook</a:documentation>
+                            <ref name="boolValues" />
+                        </element>
+                    </optional>
                 </interleave>
             </element>
             <element name="corpora">

--- a/lib/controller/kontext.pyi
+++ b/lib/controller/kontext.pyi
@@ -12,7 +12,7 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 
-from typing import Any, Optional, TypeVar, Dict, List, Iterator, Callable, Tuple
+from typing import Any, Optional, TypeVar, Dict, List, Iterator, Callable, Tuple, Union
 import werkzeug.contrib.sessions
 import werkzeug.wrappers
 from controller import KonTextCookie, Controller
@@ -23,6 +23,7 @@ from main_menu import AbstractMenuItem
 
 T = TypeVar('T')
 
+JSONVal = Union[basestring, int, float, bool, None, Dict[str, Any], List[Any]]
 
 class LinesGroups(object):
 
@@ -119,6 +120,8 @@ class Kontext(Controller):
     def get_available_aligned_corpora(self) -> List[str]: ...
 
     def _add_save_menu_item(self, label:basestring, save_format:str, hint:Optional[basestring]): ...
+
+    def _create_action_log(self, user_settings:Dict[str, Any], action_name:str, proc_time:float) -> Dict[str, JSONVal]: ...
 
 
 class PluginApi(object):

--- a/lib/plugins/abstract/dispatch_hook.py
+++ b/lib/plugins/abstract/dispatch_hook.py
@@ -35,7 +35,7 @@ class AbstractDispatchHook(object):
         """
         pass
 
-    def post_dispatch(self, plugin_api, methodname, action_metadata):
+    def post_dispatch(self, plugin_api, methodname, action_metadata, log_data):
         """
         A function run right after Controller.post_dispatch and before
         Kontext.post_dispatch.
@@ -43,11 +43,15 @@ class AbstractDispatchHook(object):
         The 'action_metadata' is mutable but in this phase, changing
         it has no effect on processed action.
 
-        This hook can be used e.g. for logging and reporting.
+        This hook can be used e.g. for logging and reporting (see log_data arg).
 
         Args:
             plugin_api -- an API available to plugins (controller.plg.PluginApi)
             methodname -- processed action method
             action_metadata -- action metadata (added by @inject)
+            log_data -- an action log record created by KonText (the same data are
+                        written to the log file (if configured so)).
+                        It's OK to mutate this value as it is already been used by
+                        KonText when the func. is called.
         """
         pass

--- a/lib/plugins/lindat_piwik_tracker/__init__.py
+++ b/lib/plugins/lindat_piwik_tracker/__init__.py
@@ -109,7 +109,7 @@ class Tracker(AbstractDispatchHook):
         self.rest_methods = frozenset(['fcs'])
         self.auth_token = auth_token
 
-    def post_dispatch(self, plugin_api, methodname, action_metadata):
+    def post_dispatch(self, plugin_api, methodname, action_metadata, log_data):
         """
         Sends the tracking information to the tracking backend
         """
@@ -120,7 +120,7 @@ class Tracker(AbstractDispatchHook):
         server_name = server_names[0] if server_names else ''
         https = plugin_api.get_from_environ('HTTP_X_FORWARDED_PROTOCOL', '') == 'https'
         remote_addrs = plugin_api.get_from_environ('HTTP_X_FORWARDED_FOR',
-                                      plugin_api.get_from_environ('REMOTE_ADDR', '')).split(', ')
+                                                   plugin_api.get_from_environ('REMOTE_ADDR', '')).split(', ')
         remote_addr = remote_addrs[0] if remote_addrs else ''
         path_info = self.context_path.rstrip('/') + plugin_api.get_from_environ('PATH_INFO', '')
 


### PR DESCRIPTION
The change introduces new signature for the method `dispatch_hook.post_dispatch` (added  argument _log_data_). All the affected code has been fixed in this commit. The reason for this is to make logging of user  actions more configurable. Now it's possible to turn default logging of actions off (i.e. this includes only logging of actions - any other warnings, errors, infos are still logged to a defined file) and create a custom implementation in _dispatch_hook_'s _post_dispatch_