### PR TITLE
Allow custom time limit for KonText installation

### DIFF
--- a/conf/config.default.xml
+++ b/conf/config.default.xml
@@ -27,6 +27,7 @@
         <periodic_tasks conf="/opt/kontext/conf/beatconfig.py">celery</periodic_tasks>
         <conc_line_max_group_num>99</conc_line_max_group_num>
         <calc_backend conf="/opt/kontext/conf/celeryconfig.py">celery</calc_backend>
+        <calc_backend_time_limit>600</calc_backend_time_limit>
         <action_path_prefix/>
         <static_files_prefix>/files</static_files_prefix>
         <use_conc_toolbar>0</use_conc_toolbar>

--- a/conf/config.rng
+++ b/conf/config.rng
@@ -231,6 +231,12 @@
                             <value>celery</value>
                         </choice>
                     </element>
+                    <optional>
+                        <element name="calc_backend_time_limit">
+                            <a:documentation>Number of seconds for backend tasks to run.</a:documentation>
+                            <data type="integer" />
+                        </element>
+                    </optional>
                     <element name="action_path_prefix">
                         <a:documentation>A prefix for action URLs (e.g. /apps/kontext). This can be used
                         to solve issues regarding apps installed in URL sub-directories</a:documentation>

--- a/conf/config.sample.xml
+++ b/conf/config.sample.xml
@@ -26,6 +26,7 @@
         <periodic_tasks conf="/path/to/beatconfig.py">celery</periodic_tasks>
         <conc_line_max_group_num>99</conc_line_max_group_num>
         <calc_backend conf="/path/to/celeryconfig.py">celery</calc_backend>
+        <calc_backend_time_limit>600</calc_backend_time_limit>
         <action_path_prefix />
         <static_files_prefix>/files</static_files_prefix>
         <use_conc_toolbar>0</use_conc_toolbar>

--- a/scripts/migration/to-0.12/update_conf.py
+++ b/scripts/migration/to-0.12/update_conf.py
@@ -41,6 +41,17 @@ def update_2(doc):
         new_elm.tail = '\n      '
 
 
+def update_3(doc):
+    srch = doc.find('/global/calc_backend')
+    if srch is not None:
+        parent = srch.getparent()
+        new_elm = etree.Element('calc_backend_time_limit')
+        new_elm.text = '300'
+        new_elm.tail = '\n        '
+        srch.tail = '\n        '
+        parent.insert(parent.index(srch) + 1, new_elm)
+
+
 if __name__ == '__main__':
     import argparse
     argparser = argparse.ArgumentParser(description='Upgrade KonText config.xml version 0.11.x '


### PR DESCRIPTION
i.e. we can have a common Celery worker node for multiple
installations of KonText with different timeouts; but the
node must have big enough (or none) time limit to cover
all the KonText instances