### PR TITLE
Make FCS configurable

### DIFF
--- a/build-scripts/configs/test_config.xml
+++ b/build-scripts/configs/test_config.xml
@@ -91,12 +91,14 @@
             <item>ovm_cs_w</item>
         </default_corpora>
         <use_db_whitelist>1</use_db_whitelist>
-        <fcs_search_attributes>
-		<item>lemma</item>
-		<item>lc</item>
-		<item>word</item>
-	</fcs_search_attributes>
     </corpora>
+    <fcs>
+        <search_attributes>
+		    <item>lemma</item>
+		    <item>lc</item>
+		    <item>word</item>
+	    </search_attributes>
+    </fcs>
     <plugins>
         <db>
             <module>lindat_db</module>

--- a/conf/config.default.xml
+++ b/conf/config.default.xml
@@ -74,6 +74,7 @@
         <left_interval_char/>
         <interval_char>±</interval_char>
     </corpora>
+    <fcs />
     <plugins>
         <application_bar/>
         <auth>
@@ -157,5 +158,6 @@
         <issue_reporting/>
         <token_connect />
         <kwic_connect />
+        <dispatch_hook />
     </plugins>
 </kontext>

--- a/conf/config.rng
+++ b/conf/config.rng
@@ -449,11 +449,45 @@
                             <text />
                         </element>
                     </optional>
+                </interleave>
+            </element>
+            <element name="fcs">
+                <interleave>
                     <optional>
-                        <element name="fcs_search_attributes">
+                        <element name="provider_heading">
+                            <text />
+                        </element>
+                    </optional>
+                    <optional>
+                        <element name="provider_website">
+                            <text />
+                        </element>
+                    </optional>
+                    <optional>
+                        <element name="template_css_url">
+                            <choice>
+                                <text />
+                                <oneOrMore>
+                                    <element name="item">
+                                        <text />
+                                    </element>
+                                </oneOrMore>
+                            </choice>
+                        </element>
+                    </optional>
+                    <optional>
+                        <element name="template_header_inject_file">
+                            <text />
+                        </element>
+                    </optional>
+                    <optional>
+                        <element name="search_attributes">
                             <oneOrMore>
                                 <element name="item">
-                                    <a:documentation>A positional attribute used for search</a:documentation>
+                                    <a:documentation>A positional attribute used for search. A list of
+                                        possible candidates is expected to satisfy any installed corpus.
+                                        From these candidates, first applicable value is always used.
+                                    </a:documentation>
                                     <text />
                                 </element>
                             </oneOrMore>

--- a/conf/config.sample.xml
+++ b/conf/config.sample.xml
@@ -1,4 +1,12 @@
 <kontext>
+    <!--
+    Please note that this file is not intended to be used as a starting
+    point to create your own configuration. It is rather a part of
+    documentation (along with config.rng).
+
+    If you want a working minimalist configuration to start with
+    then please look at config.default.xml
+    -->
     <theme>
         <name>default</name>
         <css />
@@ -72,12 +80,20 @@
         <right_interval_char>+</right_interval_char>
         <left_interval_char/>
         <interval_char>±</interval_char>
-        <fcs_search_attributes>
+    </corpora>
+    <fcs>
+        <search_attributes>
             <item>lemma</item>
             <item>lc</item>
             <item>word</item>
-        </fcs_search_attributes>
-    </corpora>
+        </search_attributes>
+        <provider_heading>ACME FCS Provider</provider_heading>
+        <provider_website>http://our_domain/our_institution</provider_website>
+        <template_css_url>
+            <item>/kontext/files/dist/fcs.css</item>
+        </template_css_url>
+        <template_header_inject_file>/path/to/an/injected/html/header/html/code</template_header_inject_file>
+    </fcs>
     <plugins>
         <application_bar />
         <auth>
@@ -178,6 +194,9 @@
             <js_module>defaultKwicConnect</js_module>
             <providers_conf extension-by="default">path/to/providers/conf.json</providers_conf>
         </kwic_connect>
+        <dispatch_hook>
+            <module>acme_custom_logging</module>
+        </dispatch_hook>
     </plugins>
 </kontext>
 

--- a/lib/actions/fcs.py
+++ b/lib/actions/fcs.py
@@ -26,7 +26,7 @@ class Actions(Kontext):
         ui_lang -- a language code in which current action's result will be presented
         """
         super(Actions, self).__init__(request=request, ui_lang=ui_lang)
-        self.search_attrs = settings.get('corpora', 'fcs_search_attributes', ['word'])
+        self.search_attrs = settings.get('fcs', 'search_attributes', ['word'])
 
     def get_mapping_url_prefix(self):
         """
@@ -316,7 +316,17 @@ class Actions(Kontext):
             Returns XSL template for rendering FCS XML.
         """
         self._headers['Content-Type'] = 'text/xsl; charset=utf-8'
-        return {}
+        custom_hd_inject_path = settings.get('fcs', 'template_header_inject_file', None)
+        if custom_hd_inject_path:
+            with open(custom_hd_inject_path) as fr:
+                custom_hdr_inject = fr.read()
+        else:
+            custom_hdr_inject = None
+
+        return dict(fcs_provider_heading=settings.get('fcs', 'provider_heading', 'KonText FCS Data Provider'),
+                    fcs_provider_website=settings.get('fcs', 'provider_website', None),
+                    fcs_template_css_url=settings.get_list('fcs', 'template_css_url'),
+                    fcs_custom_hdr_inject=custom_hdr_inject)
 
 
 class Languages(object):

--- a/lib/settings.py
+++ b/lib/settings.py
@@ -33,7 +33,7 @@ _meta = {}  # contains data of attributes of XML elements representing configura
 _help_links = {}
 _state = ConfState()
 
-SECTIONS = ('global', 'theme', 'plugins', 'cache', 'corpora', 'logging', 'mailing')
+SECTIONS = ('global', 'theme', 'plugins', 'cache', 'corpora', 'logging', 'mailing', 'fcs')
 
 DEFAULT_DATETIME_FORMAT = '%Y-%m-%d %H:%M:%S'
 
@@ -223,7 +223,8 @@ def parse_config(path):
                 _conf[section_id], _meta[section_id] = parse_config_section(section)
             else:
                 for item in section:
-                    _conf['plugins'][item.tag], _meta['plugins'][item.tag] = parse_config_section(item)
+                    _conf['plugins'][item.tag], _meta['plugins'][item.tag] = parse_config_section(
+                        item)
 
 
 def _load_help_links():

--- a/public/files/css/fcs.less
+++ b/public/files/css/fcs.less
@@ -1,0 +1,79 @@
+@import "./shared/globals.less";
+
+body {
+    font-family: @default-font-family;
+    color: @color-default-text;
+    background-image: @main-background;
+    font-size: 10pt;
+    margin: 0;
+    padding: 0;
+    height: 100%;
+}
+
+.navbar {
+    background-color: rgb(35, 31, 32);
+    color: #FFFFFF;
+    padding-top: 0.7em;
+    padding-bottom: 1em;
+
+    .collapse {
+        text-align: right;
+    }
+
+    ul.nav {
+        display: inline-block;
+        list-style-type: none;
+        margin: 0.85em 0 0 0;
+        padding: 0;
+
+        li {
+            font-size: 1.1em;
+            display: inline-block;
+            vertical-align: middle;
+
+            a {
+                color: #FFFFFF;
+                text-decoration: none;
+            }
+
+            a:hover {
+                text-decoration: underline;
+            }
+        }
+
+        li:not(last-child) {
+            margin-right: 1em;
+        }
+    }
+
+    ul.navbar-right {
+        margin-top: 0.7em;
+    }
+
+    .navbar-header {
+        background: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4NCjwhLS0gR2VuZXJhdG9yOiBBZG9iZSBJbGx1c3RyYXRvciAxNC4wLjAsIFNWRyBFeHBvcnQgUGx1Zy1JbiAuIFNWRyBWZXJzaW9uOiA2LjAwIEJ1aWxkIDQzMzYzKSAgLS0+DQo8IURPQ1RZUEUgc3ZnIFBVQkxJQyAiLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4iICJodHRwOi8vd3d3LnczLm9yZy9HcmFwaGljcy9TVkcvMS4xL0RURC9zdmcxMS5kdGQiPg0KPHN2ZyB2ZXJzaW9uPSIxLjEiIGlkPSJWcnN0dmFfMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgeD0iMHB4IiB5PSIwcHgiDQoJIHdpZHRoPSI5NS44NzRweCIgaGVpZ2h0PSIyOS4zMTdweCIgdmlld0JveD0iMCAwIDk1Ljg3NCAyOS4zMTciIGVuYWJsZS1iYWNrZ3JvdW5kPSJuZXcgMCAwIDk1Ljg3NCAyOS4zMTciIHhtbDpzcGFjZT0icHJlc2VydmUiPg0KPHBhdGggZmlsbD0iIzUzQUEyOCIgZD0iTTQ5LjYsMjEuNjUyYy00LjA1NSwwLTcuMzQxLTMuMjg2LTcuMzQxLTcuMzQxYzAtNC4wNTQsMy4yODYtNy4zNDEsNy4zNDEtNy4zNDENCgljNC4wNTQsMCw3LjM0LDMuMjg3LDcuMzQsNy4zNDFDNTYuOTQsMTguMzY2LDUzLjY1NCwyMS42NTIsNDkuNiwyMS42NTIgTTQ5LjQ0OCwzLjkwNGMtNS42NDYsMC0xMC4yMjUsNC41NzctMTAuMjI1LDEwLjIyNg0KCWMwLDUuMTU3LDMuODIyLDkuNDIyLDguNzg4LDEwLjEyMXYzLjgyMmMwLDAuNjc1LDAuNTkzLDEuMjIyLDEuMzI0LDEuMjIyYzAuNzMyLDAsMS4zMjUtMC41NDcsMS4zMjUtMS4yMjJ2LTMuNzk0DQoJYzUuMDc2LTAuNTk5LDkuMDEzLTQuOTE1LDkuMDEzLTEwLjE0OUM1OS42NzMsOC40ODEsNTUuMDk2LDMuOTA0LDQ5LjQ0OCwzLjkwNCIvPg0KPHJlY3QgeD0iMzMuNjI5IiB5PSIwLjAwNyIgZmlsbD0iIzAwOUVFMCIgd2lkdGg9IjEuNTgxIiBoZWlnaHQ9IjI5LjMxNSIvPg0KPHJlY3QgeD0iNjMuMTIzIiB5PSIwLjAwNyIgZmlsbD0iIzAwOUVFMCIgd2lkdGg9IjEuNTgyIiBoZWlnaHQ9IjI5LjMxNSIvPg0KPHBhdGggZmlsbD0iI0VBNjcwQyIgZD0iTTg0LjMsMTQuODJsNS4yMjcsMTIuNjA3YzAuMjQ2LDAuNTg5LDAuODYyLDAuOTYzLDEuNTM3LDAuODk3YzAuNjYxLTAuMDYsMS4yMDgtMC41MzIsMS4zMzMtMS4xNTENCglsMy40MjktMTYuOTFjMC4wNzQtMC4zNjIsMC0wLjczMS0wLjIwOS0xLjA0MWMtMC4yMjQtMC4zMzItMC41NzEtMC41NTctMC45NzgtMC42MzNjLTAuMDk2LTAuMDE3LTAuMTkyLTAuMDI2LTAuMjg5LTAuMDI2DQoJYy0wLjcxNywwLTEuMzM1LDAuNDg4LTEuNDcyLDEuMTU5bC0yLjQ1MSwxMi4wOWwtNC4yNS0xMC4yNDhjLTAuMTkxLTAuNDYyLTAuNjMyLTAuODAyLTEuMTQ2LTAuODg0DQoJYy0wLjUyNS0wLjA4NS0xLjA1MSwwLjEwMy0xLjM5LDAuNDc5bC0yLjcyOCwzLjAzNGwtMy41MTItOC44MzhjLTAuMjIxLTAuNTUyLTAuNzg1LTAuOTIzLTEuNDA1LTAuOTIzDQoJYy0wLjYzOSwwLjAwNS0xLjIwMSwwLjM4NS0xLjQxNCwwLjk0NWwtNi4zNjgsMTYuODU0Yy0wLjEzMSwwLjM0OS0wLjExNywwLjcyOCwwLjA0MiwxLjA2NWMwLjE2OSwwLjM1NywwLjQ3MywwLjYyNiwwLjg2LDAuNzYxDQoJYzAuMTY1LDAuMDU3LDAuMzM3LDAuMDg1LDAuNTExLDAuMDg1YzAuNjMsMCwxLjE5OS0wLjM3OSwxLjQxMi0wLjk0NWw0Ljk5Mi0xMy4yMUw3OSwxNy40NmMwLjE4OCwwLjQ2OSwwLjYyNSwwLjgxNCwxLjE0NCwwLjg5OQ0KCWMwLjUyMiwwLjA4OSwxLjA1OS0wLjA5NywxLjQwMi0wLjQ3OEw4NC4zLDE0LjgyeiIvPg0KPHBhdGggZmlsbD0iI0UyMDA3QSIgZD0iTTI4LjE4NSw2LjQzOGMtMC4xNTEtMC4wNzMtMy43MjMtMS44MDEtNy4xMDEtMS44MDFsLTAuMTc2LDAuMDAxYy0yLjc4MiwwLjA1LTUuNTExLDEuMTY3LTYuNTA2LDEuNjE5DQoJYy0xLjAzMi0wLjQ1Ni0zLjkzNi0xLjYyLTYuNzExLTEuNjJMNy41MTYsNC42MzhDNC4wOTgsNC42OTgsMC43Niw2LjM3MiwwLjYxOSw2LjQ0M0MwLjI0Myw2LjYzNSwwLDcuMDYsMCw3LjUyOXYxOC4xMDMNCgljMCwwLjY1NSwwLjQ2NywxLjE4OCwxLjA0MiwxLjE4OGgwLjEyYzAuMTM5LDAsMC4yNzUtMC4wMzIsMC40MDMtMC4wOTJjMC41MjYtMC4yNTEsMy4yODEtMS41MDYsNS45ODQtMS41NTRsMC4xNDMtMC4wMDINCgljMi42NjYsMCw1LjYxMiwxLjMsNi4xNzYsMS41NjFjMC4xMjQsMC4wNTcsMC4yNTYsMC4wODcsMC4zOSwwLjA4N2gwLjEyNWMwLjAwOSwwLDAuMDE3LTAuMDAzLDAuMDI2LTAuMDA0DQoJYzAuMDA5LDAuMDAxLDAuMDE3LDAuMDA0LDAuMDI1LDAuMDA0aDAuMTIyYzAuMTM3LDAsMC4yNzQtMC4wMzIsMC40MDEtMC4wOTJjMC41MjUtMC4yNTEsMy4yODItMS41MDYsNS45ODQtMS41NTRsMC4xNDQtMC4wMDINCgljMi42NjcsMCw1LjYxMywxLjMsNi4xNzUsMS41NjFjMC4xMjQsMC4wNTcsMC4yNTcsMC4wODcsMC4zOTIsMC4wODdoMC4xMjVjMC41NzQsMCwxLjA0LTAuNTMyLDEuMDQtMS4xODhWNy41MjkNCglDMjguODE2LDcuMDU1LDI4LjU2OSw2LjYyNCwyOC4xODUsNi40Mzh6IE0xMy4zNDIsMjMuOTg0Yy0xLjQwMS0wLjUzMi0zLjU1Ni0xLjE4OC01LjY1LTEuMTg4bC0wLjE3NiwwLjAwMw0KCWMtMi4wNjksMC4wMzYtNC4xLDAuNjU5LTUuNDMzLDEuMTcyVjguMzMzQzMuMTMsNy44ODQsNS4zNTUsNy4wNTIsNy41NDksNy4wMTRsMC4xNDMtMC4wMDJjMi4xNzQsMCw0LjU0NSwwLjg3LDUuNjUsMS4zMzFWMjMuOTg0eg0KCSBNMjYuNzM0LDIzLjk4NGMtMS40MDEtMC41MzItMy41NTYtMS4xODgtNS42NS0xLjE4OGwtMC4xNzYsMC4wMDNjLTIuMDcsMC4wMzYtNC4xLDAuNjU5LTUuNDM0LDEuMTcyVjguMzMzDQoJYzEuMDQ4LTAuNDQ5LDMuMjcyLTEuMjgxLDUuNDY2LTEuMzE5bDAuMTQ0LTAuMDAyYzIuMTc0LDAsNC41NDYsMC44Nyw1LjY1LDEuMzMxVjIzLjk4NHoiLz4NCjwvc3ZnPg0K');
+        background-repeat: no-repeat;
+        background-position: 0.1em 0;
+        float: left;
+        max-width: 35%;
+        padding-left: 4.9em;
+        font-size: 1.6em;
+
+        a {
+            color: #FFFFFF;
+            text-decoration: none;
+            display: inline-block;
+            vertical-align: middle;
+            margin-top: 0.23em;
+        }
+
+        a:hover {
+            text-decoration: underline;
+        }
+    }
+}
+
+#response pre {
+    padding: 0.7em;
+    color: @color-default-text;
+}

--- a/public/files/js/pages/fcs.ts
+++ b/public/files/js/pages/fcs.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2018 Charles University in Prague, Faculty of Arts,
+ *                    Institute of the Czech National Corpus
+ * Copyright (c) 2018 Tomas Machalek <tomas.machalek@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; version 2
+ * dated June, 1991.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+declare var require:any;
+// weback - ensure an individual style (even empty one) is created for the page
+require('styles/fcs.less');
+
+/*
+There is no client-side logic for this page. It is defined just to
+include the CSS file above.
+*/

--- a/scripts/build/webpack.common.js
+++ b/scripts/build/webpack.common.js
@@ -34,6 +34,7 @@ module.exports = {
     entry: {
         coll: mkpath('js/pages/coll.ts'),
         corplist: mkpath('js/pages/corplist.ts'),
+        fcs: mkpath('js/pages/fcs.ts'),
         firstForm: mkpath('js/pages/firstForm.ts'),
         freq: mkpath('js/pages/freq.ts'),
         message: mkpath('js/pages/message.ts'),

--- a/scripts/migration/to-0.12/update_conf.py
+++ b/scripts/migration/to-0.12/update_conf.py
@@ -52,6 +52,32 @@ def update_3(doc):
         parent.insert(parent.index(srch) + 1, new_elm)
 
 
+def update_4(doc):
+    srch = doc.find('/corpora')
+    if srch is not None:
+        parent = srch.getparent()
+        new_elm = etree.Element('fcs')
+        new_elm.tail = '\n    '
+        srch.tail = '\n    '
+        parent.insert(parent.index(srch) + 1, new_elm)
+
+
+def update_5(doc):
+    srch2 = doc.find('/fcs')
+    srch2.tail = '\n    '
+    new_elm = etree.SubElement(srch2, 'search_attributes')
+    new_elm.tail = '\n    '
+    srch = doc.findall('/corpora/fcs_search_attributes/item')
+    for item in srch:
+        new_item = etree.SubElement(new_elm, 'item')
+        new_item.text = item.text
+        new_item.tail = '\n            '
+
+    rm_srch = doc.find('/corpora/fcs_search_attributes')
+    if rm_srch is not None:
+        rm_srch.getparent().remove(rm_srch)
+
+
 if __name__ == '__main__':
     import argparse
     argparser = argparse.ArgumentParser(description='Upgrade KonText config.xml version 0.11.x '

--- a/templates/fcs/fcs2html.tmpl
+++ b/templates/fcs/fcs2html.tmpl
@@ -1,49 +1,37 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<xsl:stylesheet 
-  xmlns:xsl="http://www.w3.org/1999/XSL/Transform" 
-  xmlns:lindat="http://lindat.mff.cuni.cz/services/static/fcs-utils" 
-  xmlns:sru="http://www.loc.gov/zing/srw/" 
-  xmlns:xs="http://www.w3.org/2001/XMLSchema" 
-  xmlns:fcs="http://clarin.eu/fcs/1.0" 
-  xmlns:xd="http://www.oxygenxml.com/ns/doc/xsl" 
-  version="2.0" 
+<xsl:stylesheet
+  xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+  xmlns:lindat="http://lindat.mff.cuni.cz/services/static/fcs-utils"
+  xmlns:sru="http://www.loc.gov/zing/srw/"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:fcs="http://clarin.eu/fcs/1.0"
+  xmlns:xd="http://www.oxygenxml.com/ns/doc/xsl"
+  version="2.0"
   extension-element-prefixes="sru fcs lindat xs xd"
   >
 
-    <xsl:output method="html" 
-    doctype-public="-//W3C//DTD HTML 4.01//EN" 
-    doctype-system="http://www.w3.org/TR/html4/strict.dtd" 
+    <xsl:output method="html"
+    doctype-public="-//W3C//DTD HTML 4.01//EN"
+    doctype-system="http://www.w3.org/TR/html4/strict.dtd"
   />
 
     <xsl:template match="/">
 <html>
   <head>
-        <title>LINDAT/CLARIN FCS Data Provider</title>
+        <title>${fcs_provider_heading}</title>
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-        <script src="//code.jquery.com/jquery.min.js"
-            type="text/javascript"></script>
-        <link rel="stylesheet" href="//lindat.mff.cuni.cz/static/bootstrap-3.0.3/bootstrap.min.css" />
-        <script src="//lindat.mff.cuni.cz/static/bootstrap-3.0.3/bootstrap.min.js"></script>
-
-        <script type="text/javascript">
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-          m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-         })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
-        // main LINDAT/CLARIN tracker
-        ga('create', 'UA-27008245-2', 'cuni.cz');
-        ga('send', 'pageview');
-        </script>
-
+        #for $css_url in $fcs_template_css_url
+        <link rel="stylesheet" href="${css_url}" />
+        #end for
+        ${fcs_custom_hdr_inject}
   </head>
   <body>
 
   <div style="min-height:70px">
   <nav class="navbar navbar-default navbar-fixed-top" role="navigation">
     <div class="navbar-header">
-      <a class="navbar-brand" href="http://lindat.mff.cuni.cz">LINDAT/CLARIN FCS Provider</a>
+      <a class="navbar-brand" href="${fcs_provider_website}">${fcs_provider_heading}</a>
     </div>
 
    <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
@@ -87,7 +75,7 @@
     </xsl:template>
 
 
-  <!-- http://stackoverflow.com/questions/1162352/converting-xml-to-escaped-text-in-xslt 
+  <!-- http://stackoverflow.com/questions/1162352/converting-xml-to-escaped-text-in-xslt
     - removed the namespaces for readability
   -->
     <xsl:template match="*" mode="escape">


### PR DESCRIPTION
(remove most of the hardcoded provider-dependent stuff)

## Example conf for Lindat:
(please note that you should move `corpora/fcs_search_attributes` to the new `fcs` node under a new name `search_attributes`; there is also a migration script available which can do this for you)

```xml
<fcs>
  <search_attributes>
    <item>lemma</item>
    <item>lc</item>
    <item>word</item>
  </search_attributes>
    <provider_heading>LINDAT/CLARIN FCS Provider</provider_heading>
    <provider_website>https://lindat.mff.cuni.cz/en</provider_website>
    <template_css_url>
      <item>//lindat.mff.cuni.cz/static/bootstrap-3.0.3/bootstrap.min.css</item>
    </template_css_url> 
    <template_header_inject_file>/path/to/your/conf/lindat_fcs_header.txt</1template_header_inject_file>
<fcs/>
```
### file /path/to/your/conf/lindat_fcs_header.txt

```html
<script src="//code.jquery.com/jquery.min.js"
            type="text/javascript"></script>
<script src="//lindat.mff.cuni.cz/static/bootstrap-3.0.3/bootstrap.min.js"></script>

<script type="text/javascript">
(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
 })(window,document,'script','//www.google-analytics.com/analytics.js','ga');

// main LINDAT/CLARIN tracker
ga('create', 'UA-27008245-2', 'cuni.cz');
ga('send', 'pageview');
</script>
```