### PR TITLE
Fix #2760

### DIFF
--- a/public/files/js/pages/view.ts
+++ b/public/files/js/pages/view.ts
@@ -1148,7 +1148,7 @@ export class ViewPage {
                 );
                 const ttModel = this.initTextTypesModel();
                 let syntaxViewerModel:PluginInterfaces.SyntaxViewer.IPlugin = syntaxViewerInit(this.layoutModel.pluginApi());
-                if (!syntaxViewerModel) {
+                if (!this.layoutModel.isNotEmptyPlugin(syntaxViewerModel)) {
                     syntaxViewerModel = new DummySyntaxViewModel(this.layoutModel.dispatcher);
                 }
                 const tokenConnectPlg = this.initTokenConnect();

--- a/public/files/js/plugins/empty/init.ts
+++ b/public/files/js/plugins/empty/init.ts
@@ -18,8 +18,18 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-import {IPluginApi} from '../../types/plugins';
-
+/**
+ * This type is used by KonText build scripts whenever
+ * an optional plugin is set to none (i.e. a tag without children
+ * is used in config.xml for the plug-in).
+ *
+ * TODO: This is generally better than returning null/undefined but
+ * without a common interface for all the plug-ins, we're in
+ * similar situation as in case of 'null' (we must test the plug-in
+ * instance first and then call a method of choice).
+ *
+ * See also PageModel.isNotEmptyPlugin()
+ */
 export class EmptyPlugin {
 
     getViews() {


### PR DESCRIPTION
Cause - the Syntax viewer plug-in instance has been
tested for its status using an older approach (is null
vs. is EmptyPlugin). There is still some work to do
this right as a general concept. But the concrete
issue should be fixed.