### PR TITLE
Improve struct/attr checking consistency

### DIFF
--- a/public/files/js/models/query/cqleditor/parser.ts
+++ b/public/files/js/models/query/cqleditor/parser.ts
@@ -251,9 +251,6 @@ class RuleCharMap {
                     if (this.attrHelper.structExists(structName)) {
                         inserts[structRange[0]].push(`<span title="${this.he.translate('query__structure')}">`);
                         inserts[structRange[1]+1].push('</span>');
-
-                    } else {
-                        errors.push(`${this.he.translate('query__struct_does_not_exist')}: <strong>${structName}</strong>`);
                     }
                     attrNamesInStruct.reverse();
                     attrNamesInStruct.slice(1).forEach((sa, i, arr) => {
@@ -273,6 +270,16 @@ class RuleCharMap {
                         const range = this.convertRange(v.from, v.to, chunks);
                         inserts[range[0]].push('<br />');
                     }
+                break;
+                case 'OpenStructTag':
+                case 'CloseStructTag': {
+                    const attrNamesInStruct = this.findSubRuleIn('AttName', v.from, v.to);
+                    const structTmp = attrNamesInStruct[attrNamesInStruct.length - 1];
+                    const structName = this.query.substring(structTmp.from, structTmp.to);
+                    if (!this.attrHelper.structExists(structName)) {
+                        errors.push(`${this.he.translate('query__struct_does_not_exist')}: <strong>${structName}</strong>`);
+                    }
+                }
                 break;
             }
         });

--- a/scripts/build/cql.pegjs
+++ b/scripts/build/cql.pegjs
@@ -62,8 +62,14 @@ Seq =
 
 Repetition =
     AtomQuery RepOpt?
-    / LSTRUCT Structure _ SLASH? RSTRUCT
-    / LSTRUCT SLASH _ Structure RSTRUCT
+    / OpenStructTag
+    / CloseStructTag
+
+OpenStructTag =
+    LSTRUCT Structure _ SLASH? RSTRUCT
+
+CloseStructTag =
+    LSTRUCT SLASH _ Structure RSTRUCT
 
 AtomQuery =
     Position


### PR DESCRIPTION
Test structs/attrs once a parent non-terminal finishes. This
is still not perfect but at least the behavior is now consistent
between structs/structattrs/posattrs.