### PR TITLE
Fixed `manatee` not found while installing Kontext

### DIFF
--- a/lib/plugins/default_auth/__init__.py
+++ b/lib/plugins/default_auth/__init__.py
@@ -21,61 +21,19 @@ import hashlib
 import urllib.request
 import urllib.parse
 import urllib.error
-import os
 import re
 import uuid
 import time
 import datetime
 import mailing
-from werkzeug.security import pbkdf2_hex
 from plugins.abstract.auth import AbstractInternalAuth, AuthException, SignUpNeedsUpdateException
 from translation import ugettext as _
 import plugins
 from plugins import inject
+from .tools import mk_pwd_hash, mk_pwd_hash_default, split_pwd_hash
 
 IMPLICIT_CORPUS = 'ud_fused_test_a'
 
-
-def mk_pwd_hash_default(data):
-    """
-    Returns a pbkdf2_hex hash of the passed data with default parameters
-    """
-    iterations = 1000
-    keylen = 24
-    algo = 'sha512'
-    salt = str(os.urandom(keylen))
-    return mk_pwd_hash(data, salt, iterations, keylen, algo)
-
-
-def mk_pwd_hash(data, salt, iterations, keylen, algo):
-    """
-    Returns a pbkdf2_hex hash of the passed data with specified parameters
-    """
-    hashed = pbkdf2_hex(data, salt, iterations, keylen, algo)
-    return algo + "$" + salt + ":" + str(iterations) + "$" + hashed
-
-
-def split_pwd_hash(hashed):
-    """
-    Splits a string expected to have an "algorithm$salt:iterations$hashed_pwd" format and returns a dictionary of
-    the values. For legacy pwd hashes, a dictionary with a single value (i.e. {'data': legacyHash}) is returned.
-    """
-    res = {}
-    first_split = hashed.split("$")
-    # no dollar-sign means legacy pwd format
-    if len(first_split) == 1:
-        res['data'] = hashed
-    else:
-        # expected format: "algorithm$salt:iterations$hashed_pwd"
-        if len(first_split) == 3:
-            res['algo'] = first_split[0]
-            res['salt'] = first_split[1].split(":")[0]
-            res['iterations'] = int(first_split[1].split(":")[1])
-            res['data'] = first_split[2]
-            res['keylen'] = len(res['data']) / 2
-        else:
-            raise TypeError("wrong hash format")
-    return res
 
 
 class SignUpToken(object):

--- a/lib/plugins/default_auth/mock_redis.py
+++ b/lib/plugins/default_auth/mock_redis.py
@@ -24,7 +24,7 @@ The methods necessary to mock the connection to the redis_db plugin for the need
 import hashlib
 import json
 
-from plugins.default_auth import mk_pwd_hash_default
+from plugins.default_auth.tools import mk_pwd_hash_default
 
 
 class MockRedisCommon:

--- a/lib/plugins/default_auth/scripts/install.py
+++ b/lib/plugins/default_auth/scripts/install.py
@@ -17,7 +17,7 @@ import argparse
 import json
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', '..'))
-from plugins.default_auth import mk_pwd_hash_default
+from plugins.default_auth.tools import mk_pwd_hash_default
 
 
 def import_user_redis(data):

--- a/lib/plugins/default_auth/test_default_auth.py
+++ b/lib/plugins/default_auth/test_default_auth.py
@@ -21,7 +21,8 @@ import json
 import os
 import unittest
 
-from plugins.default_auth import mk_pwd_hash_default, mk_pwd_hash, split_pwd_hash, DefaultAuthHandler
+from plugins.default_auth import DefaultAuthHandler
+from plugins.default_auth.tools import mk_pwd_hash_default, mk_pwd_hash, split_pwd_hash
 from plugins.default_auth.mock_redis import MockRedisPlugin, MockRedisCommon
 from translation import load_translations, activate
 

--- a/lib/plugins/default_auth/tools.py
+++ b/lib/plugins/default_auth/tools.py
@@ -1,0 +1,44 @@
+import os
+from werkzeug.security import pbkdf2_hex
+
+
+def mk_pwd_hash_default(data):
+    """
+    Returns a pbkdf2_hex hash of the passed data with default parameters
+    """
+    iterations = 1000
+    keylen = 24
+    algo = 'sha512'
+    salt = str(os.urandom(keylen))
+    return mk_pwd_hash(data, salt, iterations, keylen, algo)
+
+
+def mk_pwd_hash(data, salt, iterations, keylen, algo):
+    """
+    Returns a pbkdf2_hex hash of the passed data with specified parameters
+    """
+    hashed = pbkdf2_hex(data, salt, iterations, keylen, algo)
+    return algo + "$" + salt + ":" + str(iterations) + "$" + hashed
+
+
+def split_pwd_hash(hashed):
+    """
+    Splits a string expected to have an "algorithm$salt:iterations$hashed_pwd" format and returns a dictionary of
+    the values. For legacy pwd hashes, a dictionary with a single value (i.e. {'data': legacyHash}) is returned.
+    """
+    res = {}
+    first_split = hashed.split("$")
+    # no dollar-sign means legacy pwd format
+    if len(first_split) == 1:
+        res['data'] = hashed
+    else:
+        # expected format: "algorithm$salt:iterations$hashed_pwd"
+        if len(first_split) == 3:
+            res['algo'] = first_split[0]
+            res['salt'] = first_split[1].split(":")[0]
+            res['iterations'] = int(first_split[1].split(":")[1])
+            res['data'] = first_split[2]
+            res['keylen'] = len(res['data']) / 2
+        else:
+            raise TypeError("wrong hash format")
+    return res

--- a/scripts/generate_random_pwd.py
+++ b/scripts/generate_random_pwd.py
@@ -5,7 +5,7 @@ import string
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '../lib'))
 
-from plugins.default_auth import mk_pwd_hash_default
+from plugins.default_auth.tools import mk_pwd_hash_default
 
 random = ''.join([random.choice(string.ascii_letters + string.digits) for n in range(8)])
 print(random + "-" + mk_pwd_hash_default(random))

--- a/scripts/install/install.py
+++ b/scripts/install/install.py
@@ -1,7 +1,6 @@
 from typing import List
 
 import os
-import sys
 import subprocess
 import inspect
 import argparse

--- a/scripts/install/steps.py
+++ b/scripts/install/steps.py
@@ -11,8 +11,8 @@ import json
 import redis
 import random
 import string
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '../../lib'))
-from plugins.default_auth import mk_pwd_hash_default
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '../../lib/plugins/default_auth'))
+from tools import mk_pwd_hash_default
 
 WEBSERVER_USER="www-data"
 


### PR DESCRIPTION
Error resulted from adding types to type check the python code.
Password generation functions moved to separate file in default_auth plugin and imported from there by installation script.