### PR TITLE
Async is a reserved keyword starting in Python 3.7

### DIFF
--- a/lib/actions/concordance.py
+++ b/lib/actions/concordance.py
@@ -209,7 +209,7 @@ class Actions(Querying):
         conc = EmptyConc(self.corp, None)
         try:
             conc = get_conc(corp=self.corp, user_id=self.session_get('user', 'id'), q=self.args.q,
-                            fromp=self.args.fromp, pagesize=self.args.pagesize, asnc=self.args.async,
+                            fromp=self.args.fromp, pagesize=self.args.pagesize, asnc=self.args.asnc,
                             save=self.args.save, samplesize=corpus_info.sample_size)
             if conc:
                 self._apply_linegroups(conc)
@@ -292,7 +292,7 @@ class Actions(Querying):
         out['fast_adhoc_ipm'] = plugins.runtime.LIVE_ATTRIBUTES.is_enabled_for(
             self._plugin_api, self.args.corpname)
         # TODO - this condition is ridiculous - can we make it somewhat simpler/less-redundant???
-        out['running_calc'] = not out['finished'] and self.args.async and self.args.save and not out['sampled_size']
+        out['running_calc'] = not out['finished'] and self.args.asnc and self.args.save and not out['sampled_size']
         out['chart_export_formats'] = []
         with plugins.runtime.CHART_EXPORT as ce:
             out['chart_export_formats'].extend(ce.get_supported_types())
@@ -428,7 +428,7 @@ class Actions(Querying):
         if sampled_size:
             orig_conc = get_conc(corp=self.corp, user_id=self.session_get('user', 'id'),
                                  q=self.args.q[:i], fromp=self.args.fromp, pagesize=self.args.pagesize,
-                                 asnc=self.args.async, save=self.args.save)
+                                 asnc=self.args.asnc, save=self.args.save)
             concsize = orig_conc.size()
             fullsize = orig_conc.fullsize()
 
@@ -1050,7 +1050,7 @@ class Actions(Querying):
                 pfilter = [('q', 'p0 0 1 ([] within ! <err/>) within ! <corr/>')]
                 cc = get_conc(corp=self.corp, user_id=self.session_get('user', 'id'),
                               q=self.args.q + [pfilter[0][1]], fromp=self.args.fromp,
-                              pagesize=self.args.pagesize, asnc=self.args.async, save=self.args.save)
+                              pagesize=self.args.pagesize, asnc=self.args.asnc, save=self.args.save)
                 freq = cc.size()
                 err_nfilter, corr_nfilter = '', ''
                 if freq != calc_result['conc_size']:
@@ -1444,7 +1444,7 @@ class Actions(Querying):
 
             conc = get_conc(corp=self.corp, user_id=self.session_get('user', 'id'),
                             q=self.args.q, fromp=self.args.fromp, pagesize=self.args.pagesize,
-                            asnc=self.args.async, save=self.args.save, samplesize=corpus_info.sample_size)
+                            asnc=self.args.asnc, save=self.args.save, samplesize=corpus_info.sample_size)
             self._apply_linegroups(conc)
             kwic = Kwic(self.corp, self.args.corpname, conc)
             conc.switch_aligned(os.path.basename(self.args.corpname))

--- a/lib/argmapping/__init__.py
+++ b/lib/argmapping/__init__.py
@@ -218,7 +218,7 @@ class GlobalArgs(object):
     tag = Parameter[str]('')
     default_attr = Parameter[Optional[str]](None)
     save = Parameter[int](1)
-    async = Parameter[int](1)
+    asnc = Parameter[int](1)
     qmcase = Parameter[int](0)
     include_empty = Parameter[int](0)
     rlines = Parameter[str]('250')


### PR DESCRIPTION
Which means using it as a variable or attribute name is a syntax error. Since KonText claims to be compatible with Python 3.6+, we might as well future-proof it right now :)

I changed `async` to `asnc` because this renaming was already used in some places in the codebase; another option would be `async_`.

Feel free to change it to anything else you'd like, a PR was just the easiest way to communicate all the places where this needs to happen.