### PR TITLE
Create an empty impl. of taghelper to fix build error

### DIFF
--- a/public/files/js/plugins/empty/taghelper/init.ts
+++ b/public/files/js/plugins/empty/taghelper/init.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2020 Charles University, Faculty of Arts,
+ *                    Institute of the Czech National Corpus
+ * Copyright (c) 2020 Tomas Machalek <tomas.machalek@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; version 2
+ * dated June, 1991.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { PluginInterfaces } from '../../../types/plugins';
+
+
+export class EmptyTagHelperPlugin implements PluginInterfaces.TagHelper.IPlugin {
+
+    getWidgetView(
+        corpname:string,
+        tagsetInfo:Array<PluginInterfaces.TagHelper.TagsetInfo>
+    ):PluginInterfaces.TagHelper.View {
+        return null;
+    }
+
+    isActive():boolean {
+        return false;
+    }
+}
+
+const create:PluginInterfaces.TagHelper.Factory = (pluginApi) => new EmptyTagHelperPlugin();
+
+export default create;


### PR DESCRIPTION
(if there is no tagh. configured)