### PR TITLE
Introduce 'encoded selection' in liveattrs

### DIFF
--- a/public/files/js/models/textTypes/actions.ts
+++ b/public/files/js/models/textTypes/actions.ts
@@ -120,6 +120,8 @@ export namespace Actions {
     export interface AttributeTextInputChanged extends Action<{
         attrName:string;
         value:string;
+        type:TextTypes.TTSelectionTypes;
+        decodedValue?:string; // human readable alternative (if necessary)
     }> {
         name:ActionName.AttributeTextInputChanged;
     };

--- a/public/files/js/models/textTypes/common.ts
+++ b/public/files/js/models/textTypes/common.ts
@@ -155,6 +155,7 @@ export function importInitialData(data:InitialData,
                         docLabel: attrItem.attr_doc_label
                     },
                     textFieldValue: '',
+                    textFieldDecoded: '',
                     isLocked: false,
                     type: 'regexp'
                 };

--- a/public/files/js/models/textTypes/main.ts
+++ b/public/files/js/models/textTypes/main.ts
@@ -297,7 +297,8 @@ export class TextTypesModel extends StatefulModel<TextTypesModelState>
                     this.handleAttrTextInputChange(
                         state,
                         action.payload.attrName,
-                        action.payload.value
+                        action.payload.value,
+                        action.payload.decodedValue
                     );
                 });
             }
@@ -400,7 +401,7 @@ export class TextTypesModel extends StatefulModel<TextTypesModelState>
                             if (attrIdx > -1) {
                                 if (state.attributes[attrIdx].type === 'regexp') {
                                     state.attributes[attrIdx]['isLocked'] = true;
-                                
+
                                 } else {
                                     state.attributes[attrIdx] = TTSelOps.mapValues(
                                         state.attributes[attrIdx],
@@ -569,10 +570,17 @@ export class TextTypesModel extends StatefulModel<TextTypesModelState>
         }
     }
 
-    private handleAttrTextInputChange(state:TextTypesModelState, attrName:string, value:string) {
+    private handleAttrTextInputChange(
+        state:TextTypesModelState,
+        attrName:string,
+        value:string,
+        decodedValue?:string
+    ) {
+
         const attrIdx = this.getAttributeIdx(state, attrName);
         if (attrIdx) {
-            state.attributes[attrIdx] = TTSelOps.setTextFieldValue(state.attributes[attrIdx], value);
+            state.attributes[attrIdx] = TTSelOps.setTextFieldValue(
+                state.attributes[attrIdx], value, decodedValue);
         }
     }
 

--- a/public/files/js/models/textTypes/selectionOps.ts
+++ b/public/files/js/models/textTypes/selectionOps.ts
@@ -262,11 +262,23 @@ export namespace TTSelOps {
             );
     }
 
-    export function setTextFieldValue(sel:TextTypes.AnyTTSelection, value:string):TextTypes.AnyTTSelection {
-        if (sel.type === 'text' || sel.type === 'regexp') {
+    export function setTextFieldValue(
+        sel:TextTypes.AnyTTSelection,
+        value:string,
+        valueDecoded?:string
+    ):TextTypes.AnyTTSelection {
+
+        if (sel.type === 'text') {
             return {
                 ...sel,
                 textFieldValue: value
+            };
+
+        } else if (sel.type === 'regexp') {
+            return {
+                ...sel,
+                textFieldValue: value,
+                textFieldDecoded: valueDecoded ? valueDecoded : value
             };
 
         } else {

--- a/public/files/js/plugins/ucnkLiveAttributes/init.ts
+++ b/public/files/js/plugins/ucnkLiveAttributes/init.ts
@@ -103,6 +103,7 @@ const create:PluginInterfaces.LiveAttributes.Factory = (
         pluginApi,
         {
             selectionSteps: [],
+            selectionTypes: {},
             lastRemovedStep: null,
             alignedCorpora: alignedCorpora,
             initialAlignedCorpora: alignedCorpora,

--- a/public/files/js/plugins/ucnkLiveAttributes/view.tsx
+++ b/public/files/js/plugins/ucnkLiveAttributes/view.tsx
@@ -49,7 +49,7 @@ export function init({dispatcher, he, SubcmixerComponent, textTypesModel, liveAt
 
     // ----------------------------- <StepLoader /> --------------------------
 
-    const StepLoader:React.SFC<{
+    const StepLoader:React.FC<{
         idx:number;
 
     }> = (props) => {
@@ -72,14 +72,14 @@ export function init({dispatcher, he, SubcmixerComponent, textTypesModel, liveAt
 
     // ----------------------------- <SelectionSteps /> --------------------------
 
-    const SelectionSteps:React.SFC<{
+    const SelectionSteps:React.FC<{
         items:Array<TTSelectionStep|AlignedLangSelectionStep>;
         isLoading:boolean;
 
     }> = (props) => {
 
         const shortenValues = (values:Array<any>, joinChar:string) => {
-            // TODO handle regex string
+
             if (typeof(values) === 'string') {
                 return values;
             }
@@ -107,19 +107,34 @@ export function init({dispatcher, he, SubcmixerComponent, textTypesModel, liveAt
             );
         };
 
-        const renderTextTypesSel = (item:TTSelectionStep) => {
-            return item.attributes.map((attr, i) => {
-                return (
-                    <span key={i}>
-                        {i > 0 ? ', ' : ''}
-                        <strong>{attr}</strong>
+        const renderTextTypesSel = (item:TTSelectionStep) => List.map(
+            (attrName, i) => {
+                const attr = item.values[attrName];
+                if (attr.type === 'default') {
+                    return (
+                        <span key={i}>
+                            {i > 0 ? ', ' : ''}
+                            <strong>{attrName}</strong>
                             {'\u00a0\u2208\u00a0'}
-                            {'{' + shortenValues(item.values[attr], ', ') + '}'}
+                            {'{' + shortenValues(attr.selections, ', ') + '}'}
                             <br />
-                    </span>
-                );
-            });
-        };
+                        </span>
+                    );
+
+                } else {
+                    return (
+                        <span key={i}>
+                            {i > 0 ? ', ' : ''}
+                            <strong>{attrName}</strong>
+                            {'\u00a0\u2208\u00a0'}
+                            {'{' + attr.decodedValue + '}'}
+                            <br />
+                        </span>
+                    )
+                }
+            },
+            item.attributes
+        );
 
         return (
             <div className="steps">
@@ -151,7 +166,7 @@ export function init({dispatcher, he, SubcmixerComponent, textTypesModel, liveAt
 
     // ----------------------------- <RefineButton /> --------------------------
 
-    const RefineButton:React.SFC<{
+    const RefineButton:React.FC<{
         enabled:boolean;
         clickHandler:(evt:React.MouseEvent<{}>)=>void;
 
@@ -171,7 +186,7 @@ export function init({dispatcher, he, SubcmixerComponent, textTypesModel, liveAt
 
     // ----------------------------- <UndoButton /> --------------------------
 
-    const UndoButton:React.SFC<{
+    const UndoButton:React.FC<{
         enabled:boolean;
         clickHandler:(evt:React.MouseEvent<{}>)=>void;
 
@@ -190,7 +205,7 @@ export function init({dispatcher, he, SubcmixerComponent, textTypesModel, liveAt
 
     // ----------------------------- <ResetButton /> --------------------------
 
-    const ResetButton:React.SFC<{
+    const ResetButton:React.FC<{
         enabled:boolean;
         clickHandler:(evt:React.MouseEvent<{}>)=>void;
 
@@ -210,7 +225,7 @@ export function init({dispatcher, he, SubcmixerComponent, textTypesModel, liveAt
 
     // ----------------------------- <LiveAttrsView /> --------------------------
 
-    const LiveAttrsView:React.SFC<LiveAttrsModelState> = (props) => {
+    const LiveAttrsView:React.FC<LiveAttrsModelState> = (props) => {
 
         const handleRefine = () => {
             dispatcher.dispatch<Actions.RefineClicked>({
@@ -260,7 +275,7 @@ export function init({dispatcher, he, SubcmixerComponent, textTypesModel, liveAt
 
     // ----------------------------- <AlignedLangItem /> --------------------------
 
-    const AlignedLangItem:React.SFC<{
+    const AlignedLangItem:React.FC<{
         itemIdx:number;
         item:TextTypes.AlignedLanguageItem;
 
@@ -287,7 +302,7 @@ export function init({dispatcher, he, SubcmixerComponent, textTypesModel, liveAt
 
     // ----------------------------- <LiveAttrsCustomTT /> --------------------------
 
-    const LiveAttrsCustomTT:React.SFC<LiveAttrsModelState> = (props) => {
+    const LiveAttrsCustomTT:React.FC<LiveAttrsModelState> = (props) => {
 
         const renderHint = () => {
             if (props.manualAlignCorporaMode) {

--- a/public/files/js/translations/messages.cs.json
+++ b/public/files/js/translations/messages.cs.json
@@ -262,6 +262,7 @@
         "query__tt_maximize_all_lists": "Zobrazit všechny seznamy",
         "query__tt_calendar_from_date": "Od",
         "query__tt_calendar_to_date": "Do",
+        "query__tt_selected": "Vybráno",
         "query__span_from": "od",
         "query__span_to": "do",
         "query__include_kwic": "včetně KWIC",

--- a/public/files/js/translations/messages.en.json
+++ b/public/files/js/translations/messages.en.json
@@ -262,6 +262,7 @@
         "query__tt_maximize_all_lists": "Show all the lists",
         "query__tt_calendar_from_date": "From",
         "query__tt_calendar_to_date": "To",
+        "query__tt_selected": "Selected",
         "query__span_from": "From",
         "query__span_to": "To",
         "query__include_kwic": "Include KWIC",

--- a/public/files/js/translations/messages.szl.json
+++ b/public/files/js/translations/messages.szl.json
@@ -262,6 +262,7 @@
         "query__tt_maximize_all_lists": "Show all the lists",
         "query__tt_calendar_from_date": "From",
         "query__tt_calendar_to_date": "To",
+        "query__tt_selected": "Selected",
         "query__span_from": "ôd",
         "query__span_to": "do",
         "query__include_kwic": "Użyj tyż KWIC",

--- a/public/files/js/types/common.ts
+++ b/public/files/js/types/common.ts
@@ -676,6 +676,12 @@ export namespace TextTypes {
         docLabel:string;
     }
 
+    export type TTSelectionTypes = 'full'|'text'|'regexp';
+
+    export function isEncodedSelectionType(sel:TTSelectionTypes):boolean {
+        return sel === 'regexp';
+    }
+
     export interface FullAttributeSelection {
         attrInfo:TextTypes.AttrInfo;
         isInterval:boolean;
@@ -706,14 +712,13 @@ export namespace TextTypes {
         label:string;
         name:string;
         textFieldValue:string;
+        textFieldDecoded:string;
         isLocked:boolean;
         type:'regexp';
     }
 
-
     export type AnyTTSelection = TextInputAttributeSelection|FullAttributeSelection|
             RegexpAttributeSelection;
-
 
     export type ExportedSelection = {[sca:string]:Array<string>|Array<number>|string};
 

--- a/public/files/js/views/textTypes/days.tsx
+++ b/public/files/js/views/textTypes/days.tsx
@@ -148,7 +148,9 @@ export function init(dispatcher:IActionDispatcher, he:Kontext.ComponentHelpers):
                 name: ActionName.AttributeTextInputChanged,
                 payload: {
                     attrName: props.attrObj.name,
-                    value: rangeToRegexp(newState.fromDate, newState.toDate)
+                    type: props.attrObj.type,
+                    value: rangeToRegexp(newState.fromDate, newState.toDate),
+                    decodedValue: `${newState.fromDate.toISOString().split('T')[0]}, \u2026, ${newState.toDate.toISOString().split('T')[0]}`
                 }
             });
 

--- a/public/files/js/views/textTypes/index.tsx
+++ b/public/files/js/views/textTypes/index.tsx
@@ -127,7 +127,7 @@ export function init(dispatcher:IActionDispatcher, he:Kontext.ComponentHelpers, 
             } else if (props.attrObj.type === 'regexp') {
                 if (props.widget.widget === 'days') {
                     if (props.attrObj.isLocked) {
-                        return <p>Selected: {props.attrObj.textFieldValue}</p>
+                        return <p>Selected: {props.attrObj.textFieldDecoded}</p>
                     }
                     return <CalendarDaysSelector attrObj={props.attrObj} />;
                 }

--- a/public/files/js/views/textTypes/input.tsx
+++ b/public/files/js/views/textTypes/input.tsx
@@ -155,6 +155,7 @@ export function init(dispatcher:IActionDispatcher, he:Kontext.ComponentHelpers):
                 name: ActionName.AttributeTextInputChanged,
                 payload: {
                     attrName: this.props.attrObj.name,
+                    type: this.props.attrObj.type,
                     value: v
                 }
             });


### PR DESCRIPTION
This solves e.g. our calendar widget which internally produces
a regexp but a user should see a date range