### PR TITLE
make some fixes in the installation

### DIFF
--- a/conf/config.default.xml
+++ b/conf/config.default.xml
@@ -157,7 +157,8 @@
             <js_module>defaultQueryStorage</js_module>
             <page_num_records>10</page_num_records>
             <ttl_days extension-by="default">10</ttl_days>
-        </query_storage>
+    	</query_storage>
+	<query_suggest />
         <settings_storage>
             <module>default_settings_storage</module>
             <excluded_users extension-by="default">


### PR DESCRIPTION
1) we cannot use Celery 5.0.0 as it is broken
2) try to stop celery and gunicorn before installation starts
3) allow disabling https cert. checks (in case Manatee download server
   does not provide a valid certificate)
4) update config.default.xml - add missing query_suggest entry