### PR TITLE
Fix key event handling, also accept ESC only

### DIFF
--- a/public/files/js/views/query/input.tsx
+++ b/public/files/js/views/query/input.tsx
@@ -470,15 +470,17 @@ export function init({
             [ref.current]
         );
 
-        const handleKey = () => {
-            dispatcher.dispatch<Actions.ToggleQuerySuggestionWidget>({
-                name: ActionName.ToggleQuerySuggestionWidget,
-                payload: {
-                    formType: props.formType,
-                    sourceId: props.sourceId,
-                    tokenIdx: null
-                }
-            });
+        const handleKey = (e:React.KeyboardEvent) => {
+            if (e.keyCode === Keyboard.Code.ESC) {
+                dispatcher.dispatch<Actions.ToggleQuerySuggestionWidget>({
+                    name: ActionName.ToggleQuerySuggestionWidget,
+                    payload: {
+                        formType: props.formType,
+                        sourceId: props.sourceId,
+                        tokenIdx: null
+                    }
+                });
+            }
         };
 
         const handleBlur = () => {


### PR DESCRIPTION
This has been causing interesting behavior in Win 7 Chrome where
CTRL+click produced also a separate keyboard event which messed
the widget pop-up.