### PR TITLE
default_auth signup fixes

### DIFF
--- a/lib/plugins/default_auth/__init__.py
+++ b/lib/plugins/default_auth/__init__.py
@@ -289,14 +289,12 @@ class DefaultAuthHandler(AbstractInternalAuth):
         text += '\n'
         tmp = _(
             'To verify your new account {username} (full name: {firstname} {lastname}) please click the link below')
-        if type(tmp) is str:
-            tmp = tmp.decode('utf-8')
         text += tmp.format(username=username, firstname=firstname, lastname=lastname)
         text += ':\n\n'
         text += plugin_api.create_url('user/sign_up_confirm_email', dict(key=token.value))
         text += '\n\n'
-        text += time.strftime(_('The confirmation link will expire on %m/%d/%Y at %H:%M').encode(
-            'utf-8'), expir_date.timetuple()).decode('utf-8')
+        text += time.strftime(_('The confirmation link will expire on %m/%d/%Y at %H:%M'),
+                              expir_date.timetuple())
         text += '\n\n\n-----------------------------------------------\n'
         text += _('This e-mail has been generated automatically - please do not reply to it.')
         text += '\n'

--- a/lib/plugins/default_auth/__init__.py
+++ b/lib/plugins/default_auth/__init__.py
@@ -39,7 +39,8 @@ IMPLICIT_CORPUS = 'ud_fused_test_a'
 class SignUpToken(object):
 
     def __init__(self, value=None, user_data=None, label=None, ttl=300):
-        self.value = value if value is not None else hashlib.sha1(str(uuid.uuid4())).hexdigest()
+        self.value = value if value is not None else hashlib.sha1(
+            uuid.uuid4().bytes).hexdigest()
         self.user = user_data if user_data else {}
         self.label = label
         self.created = int(time.time())

--- a/public/files/js/plugins/defaultAuth/profile.ts
+++ b/public/files/js/plugins/defaultAuth/profile.ts
@@ -317,7 +317,7 @@ export class UserProfileModel extends StatelessModel<UserProfileState> {
         this.addActionHandler<Actions.SubmitSignUpDone>(
             ActionName.SubmitSignUpDone,
             (state, action) => {
-                state = this.copyState(state);
+                // state = this.copyState(state);
                 state.isBusy = false;
                 if (action.error) {
                     state.usernameAvail = false;


### PR DESCRIPTION
There were two parts incompatible with Python 3. The fix is not very controversial, I hope.

Then, there is a workaround in a SubmitSignUpDone handler. `state` is deep-copied there and modified, but not copied/assigned back. Since I have no idea how I would do that (would that trigger observers?), I simply commented out the copying and simply mutate the state -- to make it work for me.