### PR TITLE
Allow corpus names to be uppercase (by configuration)

### DIFF
--- a/conf/config.default.xml
+++ b/conf/config.default.xml
@@ -85,6 +85,7 @@
         <colls_cache_ttl>3600</colls_cache_ttl>
         <colls_cache_min_lines>50</colls_cache_min_lines>
         <conc_dir>/var/local/corpora/conc</conc_dir>
+        <lowercase_names>true</lowercase_names>
         <default_corpora>
             <item>susanne</item>
             <!-- item>insert_your_default_corpus_here</item -->

--- a/conf/config.rng
+++ b/conf/config.rng
@@ -580,6 +580,11 @@
                         be cacheable.</a:documentation>
                         <data type="positiveInteger" />
                     </element>
+                    <element name="lowercase_names">
+                        <a:documentation>Specifies whether to normalize corpus names
+                        to lowercase.</a:documentation>
+                        <data type="boolean" />
+                    </element>
                     <element name="default_corpora">
                         <a:documentation>Specifies a default corpous to be offered to a user
                         in case she does not specify anything. A list can be used to define

--- a/lib/plugins/default_auth/__init__.py
+++ b/lib/plugins/default_auth/__init__.py
@@ -103,11 +103,12 @@ class DefaultAuthHandler(AbstractInternalAuth):
 
     USER_INDEX_KEY = 'user_index'
 
-    def __init__(self, db, sessions, anonymous_user_id, login_url, logout_url, smtp_server, mail_sender,
+    def __init__(self, db, sessions, anonymous_user_id, lowercase_names: bool,
+                 login_url, logout_url, smtp_server, mail_sender,
                  confirmation_token_ttl, on_register_get_corpora):
         """
         """
-        super(DefaultAuthHandler, self).__init__(anonymous_user_id)
+        super(DefaultAuthHandler, self).__init__(anonymous_user_id, lowercase_names)
         self.db = db
         self.sessions = sessions
         self._login_url = login_url
@@ -355,6 +356,7 @@ def create_instance(conf, db, sessions):
     return DefaultAuthHandler(db=db,
                               sessions=sessions,
                               anonymous_user_id=int(plugin_conf['anonymous_user_id']),
+                              lowercase_names=conf.get('corpora', 'lowercase_names') == 'true',  # _decode_bool from default_corparch?
                               login_url=plugin_conf.get('login_url', '/user/login'),
                               logout_url=plugin_conf.get('logout_url', '/user/logoutx'),
                               smtp_server=conf.get('mailing', 'smtp_server'),


### PR DESCRIPTION
… such as old Czech corpora at Vokabulář webový.