### PR TITLE
Signup token TTL improvements

### DIFF
--- a/conf/config.default.xml
+++ b/conf/config.default.xml
@@ -106,6 +106,7 @@
             <auth_cookie_name>kontext_session</auth_cookie_name>
             <login_url>/user/login?continue=%s</login_url>
             <logout_url>/user/logout?continue=%s</logout_url>
+            <confirmation_token_ttl>3600</confirmation_token_ttl>
         </auth>
         <conc_cache>
             <module>default_conc_cache</module>
@@ -157,8 +158,8 @@
             <js_module>defaultQueryStorage</js_module>
             <page_num_records>10</page_num_records>
             <ttl_days extension-by="default">10</ttl_days>
-    	</query_storage>
-	<query_suggest />
+        </query_storage>
+        <query_suggest />
         <settings_storage>
             <module>default_settings_storage</module>
             <excluded_users extension-by="default">

--- a/lib/plugins/default_auth/__init__.py
+++ b/lib/plugins/default_auth/__init__.py
@@ -285,7 +285,10 @@ class DefaultAuthHandler(AbstractInternalAuth):
         return errors
 
     def send_confirmation_mail(self, plugin_api, user_email, username, firstname, lastname, token):
-        expir_date = datetime.datetime.now() + datetime.timedelta(seconds=self._confirmation_token_ttl)
+        expir_date = (
+            datetime.datetime.now().astimezone() +  # system timezone-aware
+            datetime.timedelta(seconds=self._confirmation_token_ttl)
+        )
         text = ''
         text += _('Hello')
         text += ',\n\n'
@@ -299,6 +302,7 @@ class DefaultAuthHandler(AbstractInternalAuth):
         text += '\n\n'
         text += time.strftime(_('The confirmation link will expire on %m/%d/%Y at %H:%M'),
                               expir_date.timetuple())
+        text += ' ({0:%Z}, {0:%z})'.format(expir_date)
         text += '\n\n\n-----------------------------------------------\n'
         text += _('This e-mail has been generated automatically - please do not reply to it.')
         text += '\n'

--- a/lib/plugins/default_auth/__init__.py
+++ b/lib/plugins/default_auth/__init__.py
@@ -37,7 +37,7 @@ IMPLICIT_CORPUS = 'ud_fused_test_a'
 
 class SignUpToken:
 
-    def __init__(self, value=None, user_data=None, label=None, ttl=300):
+    def __init__(self, value=None, user_data=None, label=None, ttl=3600):
         self.value = value if value is not None else hashlib.sha1(
             uuid.uuid4().bytes).hexdigest()
         self.user = user_data if user_data else {}
@@ -97,7 +97,7 @@ class DefaultAuthHandler(AbstractInternalAuth):
 
     MIN_USERNAME_LENGTH = 3
 
-    DEFAULT_CONFIRM_TOKEN_TTL = 60
+    DEFAULT_CONFIRM_TOKEN_TTL = 3600  # 1 hour
 
     LAST_USER_ID_KEY = 'last_user_id'
 
@@ -285,7 +285,7 @@ class DefaultAuthHandler(AbstractInternalAuth):
         return errors
 
     def send_confirmation_mail(self, plugin_api, user_email, username, firstname, lastname, token):
-        expir_date = datetime.datetime.now() + datetime.timedelta(0, self._confirmation_token_ttl)
+        expir_date = datetime.datetime.now() + datetime.timedelta(seconds=self._confirmation_token_ttl)
         text = ''
         text += _('Hello')
         text += ',\n\n'


### PR DESCRIPTION
1. This PR sets the default signup token TTL to an hour and unifies the TTL across the code (there's was 1 minute, 5 minutes) and makes the units explicit. It also advertises the setting in a default/template config.

2. Additionally, it appends timezone information to expiration time in the signup message to avoid confusion.

   This makes it easier (for an admin but also users) to realize the server is still using UTC despite being in Central Europe, and that maybe it's better to change the timezone. DST misconfiguration would probably be more obvious as well.