### PR TITLE
error_args is sometimes an Object/dict, not an Array/list

### DIFF
--- a/lib/controller/__init__.py
+++ b/lib/controller/__init__.py
@@ -669,6 +669,8 @@ class Controller(object):
         ans = create_req_arg_proxy(self._request.form, self._request.args, self._request.json)
         if return_type == 'json':
             ans.add_forced_arg('error_code', getattr(ex, 'error_code', None))
+            # TODO: cnc-tskit (Dict.fromEntries in plugins/defaultAuth/profile.ts)
+            #       expects this to be like .items(), so maybe [] instead?
             ans.add_forced_arg('error_args', getattr(ex, 'error_args', {}))
         return ans
 

--- a/public/files/js/plugins/defaultAuth/profile.ts
+++ b/public/files/js/plugins/defaultAuth/profile.ts
@@ -311,7 +311,12 @@ export class UserProfileModel extends StatelessModel<UserProfileState> {
                         });
                     },
                     (err) => {
-                        const errors = err.response['error_args'] as
+                        let _errors = err.response['error_args'];
+                        // served by lib/controller/__init__.py:672 (Controller._create_err_action_args)
+                        // so far; probably should be passed as [] directly
+                        if (typeof _errors === 'object' && Dict.empty(_errors))
+                            _errors = [];
+                        const errors = _errors as
                             Array<[keyof SubmitFormErrors, SubmitFormErrors[keyof SubmitFormErrors]]>;
                         dispatch<Actions.SubmitSignUpDone>({
                             name: ActionName.SubmitSignUpDone,


### PR DESCRIPTION
Two solutions are proposed:

1. (*preferred, but not implemented*) Directly at the source in `lib/controller/__init__,py`: `_create_err_action_args` should respond with `[]`, not `{}`, to cater to `Dict.fromEntries(errors)` in cnc-tskit.
2. At the destination, which is more messy and probably undesired.

How to test: simply introduce an error / throw an exception in default_auth's `sign_up_user` action. With the current code, the signup form would stay in a "busy" state forever because cnc-tskit's Dict.fromEntries(errors) treats an empty **object** as a truish value and then fails to process it...