### PR TITLE
Rich attributes (foundation)

### DIFF
--- a/lib/kwiclib.py
+++ b/lib/kwiclib.py
@@ -509,7 +509,7 @@ class Kwic(object):
             if item.get('class') == 'attr':
                 # TODO configurable delimiter
                 # a list is used for future compatibility
-                prev['tail_posattrs'] = item['str'].strip('/').split('/')
+                prev['tail_posattrs'] = item['str'].split('/')
             else:
                 ans.append(item)
             prev = item

--- a/public/files/js/models/concordance/main.ts
+++ b/public/files/js/models/concordance/main.ts
@@ -46,7 +46,7 @@ import { SwitchMainCorpServerArgs } from '../query/common';
 /**
  *
  */
-function importLines(data:Array<ServerLineData>, mainAttrIdx:number):Array<Line> {
+function importLines(data:Array<ServerLineData>, viewAttrs:Array<string>, mainAttrIdx:number):Array<Line> {
     let ans:Array<Line> = [];
 
     function importTextChunk(item:ServerTextChunk, id:string):TextChunk {
@@ -59,7 +59,8 @@ function importLines(data:Array<ServerLineData>, mainAttrIdx:number):Array<Line>
                 closeLink: item.close_link ? {speechPath: item.close_link.speech_path} : undefined,
                 continued: item.continued,
                 showAudioPlayer: false,
-                tailPosAttrs: item.tail_posattrs || []
+                tailPosAttrs: item.tail_posattrs || [],
+                viewAttrs: viewAttrs,
             };
 
         } else {
@@ -74,7 +75,8 @@ function importLines(data:Array<ServerLineData>, mainAttrIdx:number):Array<Line>
                 closeLink: item.close_link ? {speechPath: item.close_link.speech_path} : undefined,
                 continued: item.continued,
                 showAudioPlayer: false,
-                tailPosAttrs: tailPosattrs
+                tailPosAttrs: tailPosattrs,
+                viewAttrs: viewAttrs,
             };
         }
     }
@@ -237,7 +239,7 @@ export class ConcordanceModel extends StatefulModel<ConcordanceModelState>
                 providesAdHocIpm,
                 concSummary: lineViewProps.concSummary,
                 baseViewAttr: lineViewProps.baseViewAttr,
-                lines: importLines(initialData, viewAttrs.indexOf(lineViewProps.baseViewAttr) - 1),
+                lines: importLines(initialData, viewAttrs, viewAttrs.indexOf(lineViewProps.baseViewAttr) - 1),
                 viewAttrs,
                 numItemsInLockedGroups: lineViewProps.NumItemsInLockedGroups,
                 pagination: lineViewProps.pagination, // TODO possible mutable mess
@@ -853,9 +855,11 @@ export class ConcordanceModel extends StatefulModel<ConcordanceModelState>
     }
 
     private importData(state:ConcordanceModelState, data:AjaxConcResponse):void {
+        const viewAttrs = this.getViewAttrs();
         state.lines = importLines(
             data.Lines,
-            this.getViewAttrs().indexOf(state.baseViewAttr) - 1
+            viewAttrs,
+            viewAttrs.indexOf(state.baseViewAttr) - 1
         );
         state.numItemsInLockedGroups = data.num_lines_in_groups;
         state.pagination = data.pagination;

--- a/public/files/js/types/concordance.ts
+++ b/public/files/js/types/concordance.ts
@@ -25,15 +25,20 @@ export interface ConcToken {
 }
 
 
-export class TextChunk {
-    id:string;
+export class TextChunkBase implements ConcToken {
     className:string;
     text:Array<string>;
+    tailPosAttrs:Array<string>;
+    viewAttrs:Array<string>;
+}
+
+
+export class TextChunk extends TextChunkBase {
+    id:string;
     openLink:{speechPath:string};
     closeLink:{speechPath:string};
     continued:boolean;
     showAudioPlayer:boolean;
-    tailPosAttrs:Array<string>;
 }
 
 

--- a/public/files/js/views/concordance/lines.tsx
+++ b/public/files/js/views/concordance/lines.tsx
@@ -196,7 +196,7 @@ export function init({dispatcher, he, lineModel, lineSelectionModel,
                         {props.data.text.join(' ')}
                     </mark>
                     {props.data.tailPosAttrs.length > 0 ?
-                        <span className="tail attr" style={props.viewMode === ViewOptions.AttrViewMode.VISIBLE_MULTILINE && props.data.tailPosAttrs.length === 0 ? {display: 'none'} : null}>
+                        <span className="tail attr">
                             {props.viewMode !== ViewOptions.AttrViewMode.VISIBLE_MULTILINE ? ATTR_SEPARATOR : ''}
                             {props.data.tailPosAttrs.join(ATTR_SEPARATOR) || '\u00a0'}
                         </span> :

--- a/public/files/js/views/concordance/lines.tsx
+++ b/public/files/js/views/concordance/lines.tsx
@@ -51,6 +51,7 @@ export interface LinesViews {
 }
 
 const ATTR_SEPARATOR = '/';
+const EMPTY_ATTRS_PLACEHOLDER = '\u00a0'; // non-breaking space
 
 
 export function init({dispatcher, he, lineModel, lineSelectionModel,
@@ -198,7 +199,7 @@ export function init({dispatcher, he, lineModel, lineSelectionModel,
                     {props.data.tailPosAttrs.length > 0 ?
                         <span className="tail attr">
                             {props.viewMode !== ViewOptions.AttrViewMode.VISIBLE_MULTILINE ? ATTR_SEPARATOR : ''}
-                            {props.data.tailPosAttrs.join(ATTR_SEPARATOR) || '\u00a0'}
+                            {props.data.tailPosAttrs.join(ATTR_SEPARATOR) || EMPTY_ATTRS_PLACEHOLDER}
                         </span> :
                         null
                     }

--- a/public/files/js/views/concordance/lines.tsx
+++ b/public/files/js/views/concordance/lines.tsx
@@ -180,6 +180,10 @@ export function init({dispatcher, he, lineModel, lineSelectionModel,
 
     }> = (props) => {
 
+        const attrs = props.data.tailPosAttrs.filter(
+            (val) => val // .length > 0
+        );
+
         const mkClass = () => `${props.supportsTokenConnect ? 'active' : ''} ${props.data.className}`;
 
         if (props.data.className === 'strc') {
@@ -187,7 +191,7 @@ export function init({dispatcher, he, lineModel, lineSelectionModel,
 
         } else if (props.viewMode === ViewOptions.AttrViewMode.MOUSEOVER ||
                 props.viewMode === ViewOptions.AttrViewMode.VISIBLE_KWIC && !props.isKwic) {
-            const title = props.data.tailPosAttrs.length > 0 ? props.data.tailPosAttrs.join(ATTR_SEPARATOR) : null;
+            const title = attrs.length > 0 ? attrs.join(ATTR_SEPARATOR) : null;
             return <mark data-tokenid={props.tokenId} className={mkClass()} title={title}>{props.data.text.join(' ')}</mark>;
 
         } else {
@@ -196,10 +200,10 @@ export function init({dispatcher, he, lineModel, lineSelectionModel,
                     <mark data-tokenid={props.tokenId} className={mkClass()}>
                         {props.data.text.join(' ')}
                     </mark>
-                    {props.data.tailPosAttrs.length > 0 ?
+                    {attrs.length > 0 ?
                         <span className="tail attr">
                             {props.viewMode !== ViewOptions.AttrViewMode.VISIBLE_MULTILINE ? ATTR_SEPARATOR : ''}
-                            {props.data.tailPosAttrs.join(ATTR_SEPARATOR) || EMPTY_ATTRS_PLACEHOLDER}
+                            {attrs.join(ATTR_SEPARATOR) || EMPTY_ATTRS_PLACEHOLDER}
                         </span> :
                         null
                     }

--- a/public/files/js/views/concordance/lines.tsx
+++ b/public/files/js/views/concordance/lines.tsx
@@ -194,7 +194,7 @@ export function init({dispatcher, he, lineModel, lineSelectionModel,
 
         } else if (props.viewMode === ViewOptions.AttrViewMode.MOUSEOVER ||
                 props.viewMode === ViewOptions.AttrViewMode.VISIBLE_KWIC && !props.isKwic) {
-            const title = attrs.length > 0 ? attrs.map(([attr, val]) => `${attr}: ${val}`).join('\n') : null;
+            const title = attrs.length > 0 ? attrs.map(([attr, val]) => `${attr}: ${val}`).join('\n') : "";
             return <mark data-tokenid={props.tokenId} className={mkClass()} title={title}>{props.data.text.join(' ')}</mark>;
 
         } else {

--- a/public/files/js/views/concordance/lines.tsx
+++ b/public/files/js/views/concordance/lines.tsx
@@ -201,10 +201,7 @@ export function init({dispatcher, he, lineModel, lineSelectionModel,
                         {props.data.text.join(' ')}
                     </mark>
                     {attrs.length > 0 ?
-                        <span className="tail attr">
-                            {props.viewMode !== ViewOptions.AttrViewMode.VISIBLE_MULTILINE ? ATTR_SEPARATOR : ''}
-                            {attrs.join(ATTR_SEPARATOR) || EMPTY_ATTRS_PLACEHOLDER}
-                        </span> :
+                        <TokenAttributes attrs={attrs} viewMode={props.viewMode} /> :
                         null
                     }
                 </>
@@ -212,6 +209,31 @@ export function init({dispatcher, he, lineModel, lineSelectionModel,
         }
     }
 
+    // ------------------------- <TokenAttributes /> -------------------------
+
+    const TokenAttributes: React.FC<{
+        attrs: Array<string>;
+        viewMode: ViewOptions.AttrViewMode;
+
+    }> = (props) => {
+
+        return (
+            <span className="tail attr">
+                {props.viewMode !== ViewOptions.AttrViewMode.VISIBLE_MULTILINE ? ATTR_SEPARATOR : ''}
+                {
+                    props.attrs.length > 0 ?
+                        // props.attrs.join(ATTR_SEPARATOR) :
+                        props.attrs.map((val, i) =>
+                            <React.Fragment key={i}>
+                                {i !== 0 ? ATTR_SEPARATOR : ''}
+                                <span>{val}</span>
+                            </React.Fragment>
+                        ) :
+                        EMPTY_ATTRS_PLACEHOLDER
+                }
+            </span>
+        );
+    }
 
     // ------------------------- <NonKwicText /> ---------------------------
 


### PR DESCRIPTION
This MR allows for custom coloring via CSS styles, if supplied.
Token attributes are separated into a new component.

The commits here are a client-side reimplementation of a similar (server-based) functionality used in a (dated) KonText instance at Vokabulář webový <https://korpus.vokabular.ujc.cas.cz>

A follow-up branch with extra work can be seen in our fork: <https://github.com/Vokabular/kontext/commits/vw-rich-attributes>

@tomachalek: Could you please consider giving this, or even the extended version, a look (**as time allows**)? My aim is to bring as much as I can upstream (to solve a bit-rotting situation I have had for like 2 years now). Thanks to you, most modifications from VW have already been merged.

Regarding the extended version, I think I might have to separate CSS to an own file, move functions from Token to a custom module, perhaps...