### PR TITLE
Log a point of plug-in installation start

### DIFF
--- a/lib/plugins/__init__.py
+++ b/lib/plugins/__init__.py
@@ -183,6 +183,7 @@ def install_plugin(name: str, module, config) -> Any:
     returns:
         an initialized plug-in instance
     """
+    logging.getLogger(__name__).info(f'installing plug-in {name}')
     _plugins[name] = module.create_instance(*(config,))
     return _plugins[name]
 


### PR DESCRIPTION
... so we can log possible errors more easily