### PR TITLE
Fix updating of concordance caches in different calc. modes

### DIFF
--- a/lib/actions/concordance.py
+++ b/lib/actions/concordance.py
@@ -457,7 +457,7 @@ class Actions(Querying):
             if cache_status is None:  # conc is not cached nor calculated
                 raise NotFoundException('Concordance calculation is lost')
             elif not cache_status.finished and cache_status.task_id:
-                # we must also test directly a respective task as might have been killed
+                # we must also test directly a respective task as it might have been killed
                 # and thus failed to store info to cache metadata
                 worker = calc_backend_client(settings)
                 err = worker.get_task_error(cache_status.task_id)

--- a/lib/plugins/abstract/conc_cache.py
+++ b/lib/plugins/abstract/conc_cache.py
@@ -46,11 +46,11 @@ class UnrecognizedSerializedException(ConcCacheStatusException):
 
 
 @dataclass
-class ConcCacheStatus(object):
+class ConcCacheStatus:
 
     task_id: Optional[str] = field(default=None)
     concsize: int = field(default=0)
-    fullsize: int = field(default=-0)
+    fullsize: int = field(default=0)
     relconcsize: float = field(default=0)
     arf: float = field(default=0)
     error: Union[Exception, str, None] = field(default=None)
@@ -61,6 +61,16 @@ class ConcCacheStatus(object):
     pid: int = field(default_factory=lambda: os.getpid())
     created: int = field(default_factory=lambda: int(time.time()))
     last_upd: int = field(default_factory=lambda: int(time.time()))
+
+    def recalc_relconcsize(self, corp: AbstractKCorpus):
+        """
+        Update relative frequency based on current fullsize/concsize and provided corpus (and its size).
+        Please note that ARF is not updated here as it requires a respective (finished) concordance instance.
+        """
+        if self.fullsize > 0:
+            self.relconcsize = 1000000.0 * self.fullsize / corp.search_size
+        else:
+            self.relconcsize = 1000000.0 * self.concsize / corp.search_size
 
     @staticmethod
     def from_storage(


### PR DESCRIPTION
Previously in some cases, the calculation finished with
incomplete/incorrect information shown about conc sizes (e.g. ipm=0)