### PR TITLE
Aiomysql refactor

### DIFF
--- a/lib/action/decorators.py
+++ b/lib/action/decorators.py
@@ -111,7 +111,7 @@ def http_action(
                 amodel.init_session()
                 await amodel.pre_dispatch(None)
                 ans = await func(amodel, req, resp, **kw)
-                amodel.post_dispatch(aprops, ans, None)  # TODO error desc
+                await amodel.post_dispatch(aprops, ans, None)  # TODO error desc
                 return HTTPResponse(
                     body=await _output_result(
                         app=application,

--- a/lib/action/model/authorized.py
+++ b/lib/action/model/authorized.py
@@ -313,8 +313,8 @@ class UserActionModel(BaseActionModel):
 
         if plugins.runtime.APPLICATION_BAR.exists:
             application_bar = plugins.runtime.APPLICATION_BAR.instance
-            result['app_bar'] = application_bar.get_contents(plugin_ctx=self.plugin_ctx,
-                                                             return_url=self.return_url)
+            result['app_bar'] = await application_bar.get_contents(plugin_ctx=self.plugin_ctx,
+                                                                   return_url=self.return_url)
             result['app_bar_css'] = application_bar.get_styles(plugin_ctx=self.plugin_ctx)
             result['app_bar_js'] = application_bar.get_scripts(plugin_ctx=self.plugin_ctx)
         else:

--- a/lib/action/model/authorized.py
+++ b/lib/action/model/authorized.py
@@ -51,8 +51,8 @@ class UserActionModel(BaseActionModel):
         # generates (sub)corpus objects with additional properties
         self.cm: Optional[corplib.CorpusManager] = None
 
-    def pre_dispatch(self, req_args):
-        req_args = super().pre_dispatch(req_args)
+    async def pre_dispatch(self, req_args):
+        req_args = await super().pre_dispatch(req_args)
         with plugins.runtime.DISPATCH_HOOK as dhook:
             dhook.pre_dispatch(self.plugin_ctx, self._action_props, self._req)
 

--- a/lib/action/model/base.py
+++ b/lib/action/model/base.py
@@ -125,7 +125,7 @@ class BaseActionModel:
                     'Unknown output format: {0}'.format(self._req.args.get('format')))
         return create_req_arg_proxy(self._req.form, self._req.args, self._req.json)
 
-    def post_dispatch(self, action_props: ActionProps, result, err_desc):
+    async def post_dispatch(self, action_props: ActionProps, result, err_desc):
         pass
 
 

--- a/lib/action/model/wordlist.py
+++ b/lib/action/model/wordlist.py
@@ -67,15 +67,15 @@ class WordlistActionModel(CorpusActionModel):
                 self._active_q_data['form'], id=self._active_q_data['id'])
         return ans
 
-    def post_dispatch(self, action_props: ActionProps, result: Dict[str, Any], err_desc):
-        super().post_dispatch(action_props, result, err_desc)
+    async def post_dispatch(self, action_props: ActionProps, result: Dict[str, Any], err_desc):
+        await super().post_dispatch(action_props, result, err_desc)
         if action_props.mutates_result:
             with plugins.runtime.QUERY_HISTORY as qh, plugins.runtime.QUERY_PERSISTENCE as qp:
-                query_id = qp.store(user_id=self.session_get('user', 'id'),
+                query_id = await qp.store(user_id=self.session_get('user', 'id'),
                                     curr_data=dict(form=self._curr_wlform_args.to_qp(),
                                                    corpora=[self._curr_wlform_args.corpname],
                                                    usesubcorp=self._curr_wlform_args.usesubcorp))
-                ts = qh.store(
+                ts = await qh.store(
                     user_id=self.session_get('user', 'id'),
                     query_id=query_id, q_supertype='wlist')
                 for fn in self._on_query_store:

--- a/lib/plugin_types/appbar.py
+++ b/lib/plugin_types/appbar.py
@@ -57,7 +57,7 @@ class AbstractApplicationBar(abc.ABC):
         return None
 
     @abc.abstractmethod
-    def get_contents(self, plugin_ctx: 'PluginCtx', return_url: str) -> str:
+    async def get_contents(self, plugin_ctx: 'PluginCtx', return_url: str) -> str:
         """
         Returns standard HTML content based on set language and user identification/settings stored in cookies.
 

--- a/lib/plugin_types/auth/__init__.py
+++ b/lib/plugin_types/auth/__init__.py
@@ -135,7 +135,7 @@ class AbstractAuth(abc.ABC, metaclass=MetaAbstractAuth):
         """
 
     @abc.abstractmethod
-    def permitted_corpora(self, user_dict: UserInfo) -> List[str]:
+    async def permitted_corpora(self, user_dict: UserInfo) -> List[str]:
         """
         Return a list of corpora accessible by a user
 
@@ -171,7 +171,7 @@ class AbstractAuth(abc.ABC, metaclass=MetaAbstractAuth):
             raise ImmediateRedirectException(plugin_ctx.create_url('corpora/corplist', {}))
 
     @abc.abstractmethod
-    def get_user_info(self, plugin_ctx: 'PluginCtx') -> UserInfo:
+    async def get_user_info(self, plugin_ctx: 'PluginCtx') -> UserInfo:
         """
         Return a dictionary containing all the data about a user.
         Sensitive information like password hashes, recovery questions
@@ -191,7 +191,7 @@ class AbstractAuth(abc.ABC, metaclass=MetaAbstractAuth):
 class AbstractSemiInternalAuth(AbstractAuth):
 
     @abc.abstractmethod
-    def validate_user(self, plugin_ctx: 'PluginCtx', username: str, password: str) -> UserInfo:
+    async def validate_user(self, plugin_ctx: 'PluginCtx', username: str, password: str) -> UserInfo:
         """
         Tries to find a user with matching 'username' and 'password'.
         If a match is found then proper credentials of the user are
@@ -231,7 +231,7 @@ class AbstractInternalAuth(AbstractSemiInternalAuth):
         """
 
     @abc.abstractmethod
-    def update_user_password(self, plugin_ctx: 'PluginCtx', user_id: int, password: str):
+    async def update_user_password(self, plugin_ctx: 'PluginCtx', user_id: int, password: str):
         """
         Changes a password of provided user.
         """
@@ -263,14 +263,14 @@ class AbstractInternalAuth(AbstractSemiInternalAuth):
         pass
 
     @abc.abstractmethod
-    def validate_new_username(self, plugin_ctx: 'PluginCtx', username: str) -> Tuple[bool, bool]:
+    async def validate_new_username(self, plugin_ctx: 'PluginCtx', username: str) -> Tuple[bool, bool]:
         """
         returns:
             a 2-tuple (availability, validity) (both bool)
         """
 
     @abc.abstractmethod
-    def sign_up_user(self, plugin_ctx: 'PluginCtx', credentials: Dict[str, Any]) -> Dict[str, str]:
+    async def sign_up_user(self, plugin_ctx: 'PluginCtx', credentials: Dict[str, Any]) -> Dict[str, str]:
         """
         returns:
             a dict where keys are form item identifiers where error occurred
@@ -279,11 +279,11 @@ class AbstractInternalAuth(AbstractSemiInternalAuth):
         pass
 
     @abc.abstractmethod
-    def sign_up_confirm(self, plugin_ctx: 'PluginCtx', key: str) -> bool:
+    async def sign_up_confirm(self, plugin_ctx: 'PluginCtx', key: str) -> bool:
         pass
 
     @abc.abstractmethod
-    def get_form_props_from_token(self, key: str) -> Dict[str, Any]:
+    async def get_form_props_from_token(self, key: str) -> Dict[str, Any]:
         pass
 
 

--- a/lib/plugin_types/auth/sign_up.py
+++ b/lib/plugin_types/auth/sign_up.py
@@ -21,19 +21,19 @@ T = TypeVar('T')
 class AbstractSignUpToken(Generic[T]):
 
     @abc.abstractmethod
-    def save(self, db: T):
+    async def save(self, db: T):
         pass
 
     @abc.abstractmethod
-    def load(self, db: T):
+    async def load(self, db: T):
         pass
 
     @abc.abstractmethod
-    def delete(self, db: T):
+    async def delete(self, db: T):
         pass
 
     @abc.abstractmethod
-    def is_valid(self, db: T):
+    async def is_valid(self, db: T):
         pass
 
     @abc.abstractmethod

--- a/lib/plugin_types/integration_db.py
+++ b/lib/plugin_types/integration_db.py
@@ -30,12 +30,12 @@ T = TypeVar('T')
 
 class AsyncDbContextManager(AbstractAsyncContextManager, Generic[T]):
     async def __aenter__(self) -> T:
-        return await super().__aenter__()
+        pass
 
 
 class DbContextManager(AbstractContextManager, Generic[T]):
     def __enter__(self) -> T:
-        return super().__enter__()
+        pass
 
 
 class IntegrationDatabase(abc.ABC, Generic[N, R, SN, SR]):

--- a/lib/plugin_types/integration_db.py
+++ b/lib/plugin_types/integration_db.py
@@ -17,14 +17,28 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 import abc
-from contextlib import AbstractAsyncContextManager
+from contextlib import AbstractAsyncContextManager, AbstractContextManager
 from typing import TypeVar, Generic, Optional
 
 N = TypeVar('N')
 R = TypeVar('R')
+SN = TypeVar('SN')
+SR = TypeVar('SR')
+
+T = TypeVar('T')
 
 
-class IntegrationDatabase(abc.ABC, Generic[N, R]):
+class AsyncDbContextManager(AbstractAsyncContextManager, Generic[T]):
+    async def __aenter__(self) -> T:
+        return await super().__aenter__()
+
+
+class DbContextManager(AbstractContextManager, Generic[T]):
+    def __enter__(self) -> T:
+        return super().__enter__()
+
+
+class IntegrationDatabase(abc.ABC, Generic[N, R, SN, SR]):
     """
     Integration DB plugin allows sharing a single database connection pool across multiple plugins
     which can be convenient in case KonText is integrated into an existing information system with
@@ -88,15 +102,23 @@ class IntegrationDatabase(abc.ABC, Generic[N, R]):
         pass
 
     @abc.abstractmethod
-    def connection(self) -> AbstractAsyncContextManager[N]:
+    def connection(self) -> AsyncDbContextManager[N]:
         """
-        Return a connection to the integration database
+        Return an async connection to the integration database from pool
         """
         pass
 
     @abc.abstractmethod
-    def cursor(self, dictionary=True) -> AbstractAsyncContextManager[R]:
+    def cursor(self, dictionary=True) -> AsyncDbContextManager[R]:
         """
-        Create a new database cursor
+        Create a new async database cursor
         """
+        pass
+
+    @abc.abstractmethod
+    def connection_sync(self) -> DbContextManager[SN]:
+        pass
+
+    @abc.abstractmethod
+    def cursor_sync(self, dictionary=True) -> DbContextManager[SR]:
         pass

--- a/lib/plugin_types/integration_db.py
+++ b/lib/plugin_types/integration_db.py
@@ -17,16 +17,11 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 import abc
-from contextlib import asynccontextmanager
-from typing import Generator, TypeVar, Generic, Optional
+from contextlib import AbstractAsyncContextManager
+from typing import TypeVar, Generic, Optional
 
 N = TypeVar('N')
 R = TypeVar('R')
-
-
-class AsyncCursor(Generic[R]):
-
-    pass
 
 
 class IntegrationDatabase(abc.ABC, Generic[N, R]):
@@ -92,17 +87,15 @@ class IntegrationDatabase(abc.ABC, Generic[N, R]):
         """
         pass
 
-    @asynccontextmanager
     @abc.abstractmethod
-    async def connection(self) -> Generator[N, None, None]:
+    def connection(self) -> AbstractAsyncContextManager[N]:
         """
         Return a connection to the integration database
         """
         pass
 
-    @asynccontextmanager
     @abc.abstractmethod
-    async def cursor(self, dictionary=True) -> Generator[R, None, None]:
+    def cursor(self, dictionary=True) -> AbstractAsyncContextManager[R]:
         """
         Create a new database cursor
         """

--- a/lib/plugin_types/integration_db.py
+++ b/lib/plugin_types/integration_db.py
@@ -91,41 +91,33 @@ class IntegrationDatabase(abc.ABC, Generic[N, R]):
         """
         pass
 
-    @property
     @abc.abstractmethod
-    def connection(self) -> N:
+    async def connection(self) -> N:
         """
         Return a connection to the integration database
         """
         pass
 
     @abc.abstractmethod
-    def cursor(self, dictionary=True, buffered=False) -> AsyncCursor[R]:
-        """
-        Create a new database cursor with asynchronous 'execute' 'executemany'
-        """
-        pass
-
-    @abc.abstractmethod
-    def cursor_sync(self, dictionary=True, buffered=False) -> R:
+    async def cursor(self, dictionary=True, buffered=False) -> R:
         """
         Create a new database cursor
         """
         pass
 
     @abc.abstractmethod
-    async def execute(self, sql, args):
+    async def execute(self, sql, args) -> R:
         pass
 
     @abc.abstractmethod
-    async def executemany(self, sql, args_rows):
+    async def executemany(self, sql, args_rows) -> R:
         """
         Execute a single query multiple times with different argument sets.
         """
         pass
 
     @abc.abstractmethod
-    def start_transaction(self, isolation_level=None):
+    async def start_transaction(self, isolation_level=None):
         """
         Start a new transaction with optional custom isolation level
         (typical values are: 'READ UNCOMMITTED', 'READ COMMITTED', 'REPEATABLE READ', 'SERIALIZABLE')
@@ -133,14 +125,14 @@ class IntegrationDatabase(abc.ABC, Generic[N, R]):
         pass
 
     @abc.abstractmethod
-    def commit(self):
+    async def commit(self):
         """
         Commit the current transaction
         """
         pass
 
     @abc.abstractmethod
-    def rollback(self):
+    async def rollback(self):
         """
         Rollback the current transaction
         """

--- a/lib/plugin_types/integration_db.py
+++ b/lib/plugin_types/integration_db.py
@@ -17,7 +17,8 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 import abc
-from typing import TypeVar, Generic, Optional
+from contextlib import asynccontextmanager
+from typing import Generator, TypeVar, Generic, Optional
 
 N = TypeVar('N')
 R = TypeVar('R')
@@ -91,49 +92,18 @@ class IntegrationDatabase(abc.ABC, Generic[N, R]):
         """
         pass
 
+    @asynccontextmanager
     @abc.abstractmethod
-    async def connection(self) -> N:
+    async def connection(self) -> Generator[N, None, None]:
         """
         Return a connection to the integration database
         """
         pass
 
+    @asynccontextmanager
     @abc.abstractmethod
-    async def cursor(self, dictionary=True, buffered=False):
+    async def cursor(self, dictionary=True) -> Generator[R, None, None]:
         """
         Create a new database cursor
-        """
-        pass
-
-    @abc.abstractmethod
-    async def execute(self, sql, args) -> R:
-        pass
-
-    @abc.abstractmethod
-    async def executemany(self, sql, args_rows) -> R:
-        """
-        Execute a single query multiple times with different argument sets.
-        """
-        pass
-
-    @abc.abstractmethod
-    async def start_transaction(self, isolation_level=None):
-        """
-        Start a new transaction with optional custom isolation level
-        (typical values are: 'READ UNCOMMITTED', 'READ COMMITTED', 'REPEATABLE READ', 'SERIALIZABLE')
-        """
-        pass
-
-    @abc.abstractmethod
-    async def commit(self):
-        """
-        Commit the current transaction
-        """
-        pass
-
-    @abc.abstractmethod
-    async def rollback(self):
-        """
-        Rollback the current transaction
         """
         pass

--- a/lib/plugin_types/integration_db.py
+++ b/lib/plugin_types/integration_db.py
@@ -99,7 +99,7 @@ class IntegrationDatabase(abc.ABC, Generic[N, R]):
         pass
 
     @abc.abstractmethod
-    async def cursor(self, dictionary=True, buffered=False) -> R:
+    async def cursor(self, dictionary=True, buffered=False):
         """
         Create a new database cursor
         """

--- a/lib/plugin_types/issue_reporting.py
+++ b/lib/plugin_types/issue_reporting.py
@@ -50,5 +50,5 @@ class AbstractIssueReporting(abc.ABC):
     def export_report_action(self, plugin_ctx: 'PluginCtx') -> Dict[Any, List[Callable[[Any], Any]]]:
         pass
 
-    def submit(self, plugin_ctx: 'PluginCtx', args: Dict[str, str]):
+    async def submit(self, plugin_ctx: 'PluginCtx', args: Dict[str, str]):
         pass

--- a/lib/plugin_types/query_history.py
+++ b/lib/plugin_types/query_history.py
@@ -34,7 +34,7 @@ from typing import Optional
 class AbstractQueryHistory(abc.ABC):
 
     @abc.abstractmethod
-    def store(self, user_id: int, query_id: str, q_supertype: str) -> int:
+    async def store(self, user_id: int, query_id: str, q_supertype: str) -> int:
         """
         Store data as a new saved query
 
@@ -51,7 +51,7 @@ class AbstractQueryHistory(abc.ABC):
         """
 
     @abc.abstractmethod
-    def make_persistent(self, user_id: int, query_id: str, q_supertype: str, created: Optional[int], name: str):
+    async def make_persistent(self, user_id: int, query_id: str, q_supertype: str, created: Optional[int], name: str):
         """
         Finds (if implemented) a specific query history
         record based on its respective concordance record.
@@ -66,14 +66,14 @@ class AbstractQueryHistory(abc.ABC):
         """
 
     @abc.abstractmethod
-    def make_transient(self, user_id: int, query_id: str, created: int, name: str):
+    async def make_transient(self, user_id: int, query_id: str, created: int, name: str):
         """
         Remove name from the history item and let it be
         removed once it gets too old
         """
 
     @abc.abstractmethod
-    def delete(self, user_id, query_id, created):
+    async def delete(self, user_id, query_id, created):
         """
         Delete a named query from history.
 
@@ -90,7 +90,7 @@ class AbstractQueryHistory(abc.ABC):
         """
 
     @abc.abstractmethod
-    def get_user_queries(self, user_id, corpus_manager, from_date=None, to_date=None, q_supertype=None, corpname=None,
+    async def get_user_queries(self, user_id, corpus_manager, from_date=None, to_date=None, q_supertype=None, corpname=None,
                          archived_only=False, offset=0, limit=None):
         """
         Returns list of queries of a specific user.

--- a/lib/plugin_types/query_persistence/__init__.py
+++ b/lib/plugin_types/query_persistence/__init__.py
@@ -69,7 +69,7 @@ class AbstractQueryPersistence(abc.ABC):
         """
 
     @abc.abstractmethod
-    def open(self, data_id: str) -> Dict:
+    async def open(self, data_id: str) -> Dict:
         """
         Load operation data according to the passed data_id argument.
         The data are assumed to be public (as are URL parameters of a query).
@@ -82,7 +82,7 @@ class AbstractQueryPersistence(abc.ABC):
         """
 
     @abc.abstractmethod
-    def store(self, user_id: int, curr_data: Dict, prev_data: Optional[Dict] = None) -> str:
+    async def store(self, user_id: int, curr_data: Dict, prev_data: Optional[Dict] = None) -> str:
         """
         Store a current operation (defined in curr_data) into the database. If also prev_date argument is
         provided then a comparison is performed and based on the result, new record is created and new
@@ -99,7 +99,7 @@ class AbstractQueryPersistence(abc.ABC):
         """
 
     @abc.abstractmethod
-    def archive(self, user_id: int, conc_id: str, revoke: bool = False) -> Tuple[int, Dict[str, Any]]:
+    async def archive(self, user_id: int, conc_id: str, revoke: bool = False) -> Tuple[int, Dict[str, Any]]:
         """
         Make the concordance record persistent. For implementations which
         archive concordances automatically this can be just an empty
@@ -120,7 +120,7 @@ class AbstractQueryPersistence(abc.ABC):
         """
 
     @abc.abstractmethod
-    def is_archived(self, conc_id: str) -> bool:
+    async def is_archived(self, conc_id: str) -> bool:
         """
         arguments:
             conc_id -- a concordance hash
@@ -130,7 +130,7 @@ class AbstractQueryPersistence(abc.ABC):
         """
 
     @abc.abstractmethod
-    def will_be_archived(self, plugin_ctx: Any, conc_id: str) -> bool:
+    async def will_be_archived(self, plugin_ctx: Any, conc_id: str) -> bool:
         """
         returns:
             True if the concordance will be archived else False
@@ -180,7 +180,7 @@ class AbstractQueryPersistence(abc.ABC):
         """
         ans = []
         attr_list = plugin_ctx.current_corpus.get_posattrs()
-        data = self.open(last_id)  # type: ignore
+        data = await self.open(last_id)
         if data is not None:
             form_data = upgrade_stored_record(data.get('lastop_form', {}), attr_list)
             ans.append(await conc_form_args_factory(
@@ -188,7 +188,7 @@ class AbstractQueryPersistence(abc.ABC):
         limit = 100
         while data is not None and data.get('prev_id') and limit > 0:
             prev_id = data['prev_id']
-            data = self.open(prev_id)  # type: ignore
+            data = await self.open(prev_id)
             if data is None:
                 raise QueryPersistenceRecNotFound(f'no data found for query "{prev_id}"')
             else:

--- a/lib/plugins/clarinsi_appbar/__init__.py
+++ b/lib/plugins/clarinsi_appbar/__init__.py
@@ -40,7 +40,7 @@ class ClarinSiTopBar(AbstractApplicationBar):
     def get_scripts(self, plugin_ctx):
         return self._js_urls
 
-    def get_contents(self, plugin_ctx, return_url):
+    async def get_contents(self, plugin_ctx, return_url):
         tpl_path = self.get_template(plugin_ctx.user_lang)
         if not os.path.exists(tpl_path):
             return f'template [{tpl_path}] does not exist!'

--- a/lib/plugins/default_auth/test_default_auth.py
+++ b/lib/plugins/default_auth/test_default_auth.py
@@ -135,11 +135,11 @@ class AuthTest(unittest.TestCase):
         """
         self.load_users()
         msg = "failed to authenticate as sample user your_user"
-        self.assertEqual('your_user', self.auth_handler.validate_user(
+        self.assertEqual('your_user', await self.auth_handler.validate_user(
             None, 'your_user', 'yourpwd').get('user'), msg)
 
         msg = "validation failed to return anonymous user for a non-existing user"
-        self.assertEqual(0, self.auth_handler.validate_user(
+        self.assertEqual(0, await self.auth_handler.validate_user(
             None, 'jimmy', 'doesNotExist').get('id'), msg)
 
     def test_validate_user_old_hashing_and_update_password(self):
@@ -154,17 +154,17 @@ class AuthTest(unittest.TestCase):
         self.assertEqual(len(self.auth_handler._find_user('mary').get('pwd_hash')), 32, msg)
 
         msg = "failed to authenticate using the old hashing method"
-        self.assertEqual('mary', self.auth_handler.validate_user(
+        self.assertEqual('mary', await self.auth_handler.validate_user(
             None, 'mary', 'maryspassword').get('user'), msg)
 
-        self.auth_handler.update_user_password(None, 2, 'marysnewpassword')
+        await self.auth_handler.update_user_password(None, 2, 'marysnewpassword')
         split_new = split_pwd_hash(self.auth_handler._find_user('mary').get('pwd_hash'))
         msg = "the password update method failed"
         self.assertTrue(len(split_new['salt']) > 0)
         self.assertTrue(len(split_new['data']) == 2 * split_new['keylen'], msg)
 
         msg = "failed to authenticate using the new hashing method"
-        self.assertEqual('mary', self.auth_handler.validate_user(
+        self.assertEqual('mary', await self.auth_handler.validate_user(
             None, 'mary', 'marysnewpassword').get('user'), msg)
 
 

--- a/lib/plugins/default_corparch/__init__.py
+++ b/lib/plugins/default_corparch/__init__.py
@@ -146,7 +146,7 @@ class DefaultCorplistProvider(CorplistProvider):
         if query is False:  # False means 'use default values'
             query = ''
         ans = {'rows': []}
-        permitted_corpora = self._auth.permitted_corpora(plugin_ctx.user_dict)
+        permitted_corpora = await self._auth.permitted_corpora(plugin_ctx.user_dict)
         used_keywords = set()
         all_keywords_map = dict(self._corparch.all_keywords(plugin_ctx))
         if filter_dict.get('minSize'):
@@ -610,8 +610,8 @@ class CorpusArchive(AbstractSearchableCorporaArchive):
         else:
             return '{0} [{1}]'.format(text, plugin_ctx.translate('translation not available'))
 
-    def _export_featured(self, plugin_ctx):
-        permitted_corpora = self._auth.permitted_corpora(plugin_ctx.user_dict)
+    async def _export_featured(self, plugin_ctx):
+        permitted_corpora = await self._auth.permitted_corpora(plugin_ctx.user_dict)
 
         def is_featured(o):
             return o.metadata.featured
@@ -639,11 +639,10 @@ class CorpusArchive(AbstractSearchableCorporaArchive):
             ans.append(tmp)
         return ans
 
-    @as_async
-    def export(self, plugin_ctx):
+    async def export(self, plugin_ctx):
         return dict(
             favorite=self.export_favorite(plugin_ctx, self._user_items.get_user_items(plugin_ctx)),
-            featured=self._export_featured(plugin_ctx),
+            featured=await self._export_featured(plugin_ctx),
             corpora_labels=[(k, lab, self.get_label_color(k))
                             for k, lab in self.all_keywords(plugin_ctx)],
             tag_prefix=self._tag_prefix,

--- a/lib/plugins/default_integration_db/__init__.py
+++ b/lib/plugins/default_integration_db/__init__.py
@@ -51,7 +51,7 @@ class DefaultIntegrationDb(IntegrationDatabase[None, None]):
     async def connection(self) -> N:
         raise PluginCompatibilityException(self._err_msg())
 
-    async def cursor(self, dictionary=True, buffered=False) -> R:
+    def cursor(self, dictionary=True, buffered=False):
         raise PluginCompatibilityException(self._err_msg())
 
     @property

--- a/lib/plugins/default_integration_db/__init__.py
+++ b/lib/plugins/default_integration_db/__init__.py
@@ -48,11 +48,10 @@ class DefaultIntegrationDb(IntegrationDatabase[None, None]):
                                             'incorrectly that a concrete instance is enabled.')
         return 'DefaultIntegrationDb provides no true database integration'
 
-    @property
-    def connection(self) -> N:
+    async def connection(self) -> N:
         raise PluginCompatibilityException(self._err_msg())
 
-    def cursor(self, dictionary=True, buffered=False) -> R:
+    async def cursor(self, dictionary=True, buffered=False) -> R:
         raise PluginCompatibilityException(self._err_msg())
 
     @property
@@ -66,19 +65,19 @@ class DefaultIntegrationDb(IntegrationDatabase[None, None]):
     def wait_for_environment(self):
         return None
 
-    def execute(self, sql, args):
+    async def execute(self, sql, args) -> R:
         raise PluginCompatibilityException(self._err_msg())
 
-    def executemany(self, sql, args_rows):
+    async def executemany(self, sql, args_rows) -> R:
         raise PluginCompatibilityException(self._err_msg())
 
-    def start_transaction(self, isolation_level=None):
+    async def start_transaction(self, isolation_level=None):
         raise PluginCompatibilityException(self._err_msg())
 
-    def commit(self):
+    async def commit(self):
         raise PluginCompatibilityException(self._err_msg())
 
-    def rollback(self):
+    async def rollback(self):
         raise PluginCompatibilityException(self._err_msg())
 
 

--- a/lib/plugins/default_integration_db/__init__.py
+++ b/lib/plugins/default_integration_db/__init__.py
@@ -51,7 +51,7 @@ class DefaultIntegrationDb(IntegrationDatabase[None, None]):
     async def connection(self) -> N:
         raise PluginCompatibilityException(self._err_msg())
 
-    def cursor(self, dictionary=True, buffered=False):
+    async def cursor(self, dictionary=True):
         raise PluginCompatibilityException(self._err_msg())
 
     @property
@@ -64,21 +64,6 @@ class DefaultIntegrationDb(IntegrationDatabase[None, None]):
 
     def wait_for_environment(self):
         return None
-
-    async def execute(self, sql, args) -> R:
-        raise PluginCompatibilityException(self._err_msg())
-
-    async def executemany(self, sql, args_rows) -> R:
-        raise PluginCompatibilityException(self._err_msg())
-
-    async def start_transaction(self, isolation_level=None):
-        raise PluginCompatibilityException(self._err_msg())
-
-    async def commit(self):
-        raise PluginCompatibilityException(self._err_msg())
-
-    async def rollback(self):
-        raise PluginCompatibilityException(self._err_msg())
 
 
 def create_instance(_):

--- a/lib/plugins/default_integration_db/__init__.py
+++ b/lib/plugins/default_integration_db/__init__.py
@@ -16,13 +16,10 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-from typing import TypeVar
+from contextlib import asynccontextmanager
 from plugin_types.integration_db import IntegrationDatabase
 from plugins.errors import PluginCompatibilityException
 import logging
-
-N = TypeVar('N')
-R = TypeVar('R')
 
 
 class DefaultIntegrationDb(IntegrationDatabase[None, None]):
@@ -48,9 +45,11 @@ class DefaultIntegrationDb(IntegrationDatabase[None, None]):
                                             'incorrectly that a concrete instance is enabled.')
         return 'DefaultIntegrationDb provides no true database integration'
 
-    async def connection(self) -> N:
+    @asynccontextmanager
+    async def connection(self):
         raise PluginCompatibilityException(self._err_msg())
 
+    @asynccontextmanager
     async def cursor(self, dictionary=True):
         raise PluginCompatibilityException(self._err_msg())
 

--- a/lib/plugins/default_integration_db/__init__.py
+++ b/lib/plugins/default_integration_db/__init__.py
@@ -16,13 +16,13 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager, contextmanager
 from plugin_types.integration_db import IntegrationDatabase
 from plugins.errors import PluginCompatibilityException
 import logging
 
 
-class DefaultIntegrationDb(IntegrationDatabase[None, None]):
+class DefaultIntegrationDb(IntegrationDatabase[None, None, None, None]):
     """
     The default integration database is designed to make sure no plug-in will try to
     use integration_db without proper status check. It means that a correct plug-in
@@ -51,6 +51,14 @@ class DefaultIntegrationDb(IntegrationDatabase[None, None]):
 
     @asynccontextmanager
     async def cursor(self, dictionary=True):
+        raise PluginCompatibilityException(self._err_msg())
+
+    @contextmanager
+    def connection_sync(self):
+        raise PluginCompatibilityException(self._err_msg())
+
+    @contextmanager
+    def cursor_sync(self, dictionary=True):
         raise PluginCompatibilityException(self._err_msg())
 
     @property

--- a/lib/plugins/default_issue_reporting/__init__.py
+++ b/lib/plugins/default_issue_reporting/__init__.py
@@ -37,7 +37,7 @@ bp = Blueprint('default_issue_reporting')
 @http_action(return_type='json', action_model=UserActionModel)
 def submit_issue(req, amodel):
     with plugins.runtime.ISSUE_REPORTING as p:
-        p.submit(amodel.plugin_ctx, req.form)
+        await p.submit(amodel.plugin_ctx, req.form)
     return {}
 
 
@@ -52,15 +52,15 @@ class DefaultErrorReporting(AbstractIssueReporting):
     def export_report_action(self, plugin_ctx):
         return DynamicReportingAction()
 
-    def submit(self, plugin_ctx, args):
-        self._send_mail(plugin_ctx, args['body'], json.loads(args['args']))
+    async def submit(self, plugin_ctx, args):
+        await self._send_mail(plugin_ctx, args['body'], json.loads(args['args']))
 
     @staticmethod
     def _dump_browser_info(info):
         return '\n'.join(('  {0}: {1}'.format(k, v)) for k, v in list(info.items()))
 
-    def _send_mail(self, plugin_ctx, body, browser_info):
-        user_info = self._auth.get_user_info(plugin_ctx)
+    async def _send_mail(self, plugin_ctx, body, browser_info):
+        user_info = await self._auth.get_user_info(plugin_ctx)
         user_email = user_info['email']
         username = user_info['username']
 

--- a/lib/plugins/default_query_persistence/__init__.py
+++ b/lib/plugins/default_query_persistence/__init__.py
@@ -216,7 +216,7 @@ class DefaultQueryPersistence(AbstractQueryPersistence):
             return self._anonymous_user_ttl_days
         return self._ttl_days
 
-    def open(self, data_id):
+    async def open(self, data_id):
         """
         Loads operation data according to the passed data_id argument.
         The data are assumed to be public (as are URL parameters of a query).
@@ -233,7 +233,7 @@ class DefaultQueryPersistence(AbstractQueryPersistence):
             ans = self._archive_backend.load(key)
         return ans
 
-    def store(self, user_id, curr_data, prev_data=None):
+    async def store(self, user_id, curr_data, prev_data=None):
         """
         Stores current operation (defined in curr_data) into the database. If also prev_date argument is
         provided then a comparison is performed and based on the result, new record is created and new
@@ -267,9 +267,9 @@ class DefaultQueryPersistence(AbstractQueryPersistence):
             latest_id = prev_data['id']
         return latest_id
 
-    def archive(self, user_id, conc_id, revoke=False):
+    async def archive(self, user_id, conc_id, revoke=False):
         key = self._mk_key(conc_id)
-        data = self.open(conc_id)
+        data = await self.open(conc_id)
         if data is None:
             raise UserActionException('Concordance key \'%s\' not found.' % (conc_id,))
         stored_user_id = data.get('user_id', None)
@@ -285,10 +285,10 @@ class DefaultQueryPersistence(AbstractQueryPersistence):
 
         return 1, data
 
-    def is_archived(self, conc_id):
+    async def is_archived(self, conc_id):
         return self._archive_backend.is_archived(self._mk_key(conc_id))
 
-    def will_be_archived(self, plugin_ctx, conc_id: str):
+    async def will_be_archived(self, plugin_ctx, conc_id: str):
         return not self.is_archived(conc_id)\
             and self._settings.get('plugins', 'query_persistence').get('implicit_archiving', None) in ('true', '1', 1)\
             and not self._auth.is_anonymous(plugin_ctx.user_id)

--- a/lib/plugins/default_syntax_viewer/__init__.py
+++ b/lib/plugins/default_syntax_viewer/__init__.py
@@ -125,7 +125,7 @@ def load_plugin_conf_from_file(plugin_conf):
         return conf_data.get('corpora', {})
 
 
-def load_plugin_conf_from_db(db: IntegrationDatabase, corp_table='kontext_corpus') -> Dict[str, str]:
+async def load_plugin_conf_from_db(db: IntegrationDatabase, corp_table='kontext_corpus') -> Dict[str, str]:
 
     def parse_conf(corp, src):
         try:
@@ -135,12 +135,12 @@ def load_plugin_conf_from_db(db: IntegrationDatabase, corp_table='kontext_corpus
                 f'Failed to load syntax viewer conf for {corp}: {ex}')
             return None
 
-    cursor = db.cursor_sync()
-    cursor.execute(
-        'SELECT name, syntax_viewer_conf_json '
-        f'FROM {corp_table} '
-        'WHERE syntax_viewer_conf_json IS NOT NULL')
-    return {row['name']: parse_conf(row['name'], row['syntax_viewer_conf_json']) for row in cursor}
+    async with db.cursor() as cursor:
+        await cursor.execute(
+            'SELECT name, syntax_viewer_conf_json '
+            f'FROM {corp_table} '
+            'WHERE syntax_viewer_conf_json IS NOT NULL')
+        return {row['name']: parse_conf(row['name'], row['syntax_viewer_conf_json']) async for row in cursor}
 
 
 @plugins.inject(plugins.runtime.AUTH, plugins.runtime.INTEGRATION_DB)
@@ -149,6 +149,7 @@ def create_instance(conf, auth, integ_db: IntegrationDatabase):
     if integ_db.is_active and 'config_path' not in plugin_conf:
         logging.getLogger(__name__).info(
             f'default_syntax_viewer uses integration_db[{integ_db.info}]')
+        # TODO asynchronous config load...
         corpora_conf = load_plugin_conf_from_db(integ_db)
     else:
         logging.getLogger(__name__).info(f'default_syntax_viewer uses config_path configuration')

--- a/lib/plugins/lindat_appbar/__init__.py
+++ b/lib/plugins/lindat_appbar/__init__.py
@@ -36,7 +36,7 @@ class LindatTopBar(AbstractApplicationBar):
     def get_scripts(self, plugin_ctx):
         return self._js_urls
 
-    def get_contents(self, plugin_ctx, return_url):
+    async def get_contents(self, plugin_ctx, return_url):
         tpl_path = self.get_template(plugin_ctx.user_lang)
         if not os.path.exists(tpl_path):
             return "template [%s] does not exist!" % tpl_path

--- a/lib/plugins/lindat_auth/__init__.py
+++ b/lib/plugins/lindat_auth/__init__.py
@@ -41,10 +41,10 @@ def uni(s):
 def lindat_login(self, request):
     with plugins.runtime.AUTH as auth:
         ans = {}
-        self._session['user'] = auth.validate_user(self._plugin_ctx,
-                                                   request.form.get(
-                                                       'username') if request.form else None,
-                                                   request.form.get('password') if request.form else None)
+        self._session['user'] = await auth.validate_user(self._plugin_ctx,
+                                                         request.form.get(
+                                                             'username') if request.form else None,
+                                                         request.form.get('password') if request.form else None)
         if not auth.is_anonymous(self._session['user'].get('id', None)):
             if request.args.get('redirectTo', None):
                 self.redirect(request.args.get('redirectTo'))
@@ -67,7 +67,7 @@ class FederatedAuthWithFailover(AbstractSemiInternalAuth):
     ID_KEYS = ('HTTP_EPPN', 'HTTP_PERSISTENT_ID', 'HTTP_MAIL')
     RESERVED_USER = '__user_count'
 
-    def get_user_info(self, plugin_ctx):
+    async def get_user_info(self, plugin_ctx):
         raise NotImplementedError()
 
     def __init__(self, corplist, db, sessions, conf, failover):
@@ -93,7 +93,7 @@ class FederatedAuthWithFailover(AbstractSemiInternalAuth):
         self._entitlement2group = {entitlement: group for entitlement, group
                                    in map(_e2g_splitter, self._conf.get('entitlements_to_groups', []))}
 
-    def validate_user(self, plugin_ctx, username, password):
+    async def validate_user(self, plugin_ctx, username, password):
         """
             Try to find the user using two methods.
         """

--- a/lib/plugins/lindat_corparch2/__init__.py
+++ b/lib/plugins/lindat_corparch2/__init__.py
@@ -265,7 +265,7 @@ class DefaultCorplistProvider(CorplistProvider):
                 + ' ' + ' '.join('%s%s' % (self._tag_prefix, s) for s in query_keywords)
 
         ans = {'rows': []}
-        permitted_corpora = self._auth.permitted_corpora(plugin_ctx.user_dict)
+        permitted_corpora = await self._auth.permitted_corpora(plugin_ctx.user_dict)
 
         if filter_dict.get('minSize'):
             min_size = l10n.desimplify_num(filter_dict.get('minSize'), strict=False)
@@ -731,8 +731,8 @@ class CorpusArchive(AbstractSearchableCorporaArchive):
         else:
             return '{0} [{1}]'.format(text, plugin_ctx.translate('translation not available'))
 
-    def _export_featured(self, plugin_ctx: PluginCtx):
-        permitted_corpora = self._auth.permitted_corpora(plugin_ctx.user_dict)
+    async def _export_featured(self, plugin_ctx: PluginCtx):
+        permitted_corpora = await self._auth.permitted_corpora(plugin_ctx.user_dict)
 
         def is_featured(o: CorpusInfo):
             return o.metadata.featured
@@ -769,7 +769,7 @@ class CorpusArchive(AbstractSearchableCorporaArchive):
 
         return dict(
             favorite=self.export_favorite(plugin_ctx, self._user_items.get_user_items(plugin_ctx)),
-            featured=self._export_featured(plugin_ctx),
+            featured=await self._export_featured(plugin_ctx),
             corpora_labels=[(k, lab, self.get_label_color(k))
                             for k, lab in await self.all_keywords(plugin_ctx)],
             initial_keywords=initial_keywords,

--- a/lib/plugins/mysql_auth/__init__.py
+++ b/lib/plugins/mysql_auth/__init__.py
@@ -29,7 +29,7 @@ import datetime
 import mailing
 import logging
 from collections import defaultdict
-import aiomysql
+from aiomysql import Connection, Cursor
 from typing import List, Union
 
 from plugin_types.auth import AbstractInternalAuth, AuthException, CorpusAccess, SignUpNeedsUpdateException
@@ -56,7 +56,7 @@ class MysqlAuthHandler(AbstractInternalAuth):
 
     def __init__(
             self,
-            db: Union[IntegrationDatabase[aiomysql.Connection, aiomysql.Cursor], MySQLOps],
+            db: Union[IntegrationDatabase[Connection, Cursor], MySQLOps],
             sessions,
             anonymous_user_id,
             case_sensitive_corpora_names: bool,
@@ -366,7 +366,7 @@ class MysqlAuthHandler(AbstractInternalAuth):
 
 
 @inject(plugins.runtime.INTEGRATION_DB, plugins.runtime.SESSIONS)
-def create_instance(conf, integ_db: IntegrationDatabase[aiomysql.Connection, aiomysql.Cursor], sessions):
+def create_instance(conf, integ_db: IntegrationDatabase[Connection, Cursor], sessions):
     """
     This function must be always implemented. KonText uses it to create an instance of your
     authentication object. The settings module is passed as a parameter.

--- a/lib/plugins/mysql_auth/__init__.py
+++ b/lib/plugins/mysql_auth/__init__.py
@@ -26,6 +26,7 @@ import urllib.error
 import re
 import time
 import datetime
+from plugins.mysql_integration_db import MySqlIntegrationDb
 import mailing
 import logging
 from collections import defaultdict
@@ -56,7 +57,7 @@ class MysqlAuthHandler(AbstractInternalAuth):
 
     def __init__(
             self,
-            db: Union[IntegrationDatabase[Connection, Cursor], MySQLOps],
+            db: Union[MySqlIntegrationDb, MySQLOps],
             sessions,
             anonymous_user_id,
             case_sensitive_corpora_names: bool,
@@ -368,7 +369,7 @@ class MysqlAuthHandler(AbstractInternalAuth):
 
 
 @inject(plugins.runtime.INTEGRATION_DB, plugins.runtime.SESSIONS)
-def create_instance(conf, integ_db: IntegrationDatabase[Connection, Cursor], sessions):
+def create_instance(conf, integ_db: MySqlIntegrationDb, sessions):
     """
     This function must be always implemented. KonText uses it to create an instance of your
     authentication object. The settings module is passed as a parameter.

--- a/lib/plugins/mysql_auth/sign_up.py
+++ b/lib/plugins/mysql_auth/sign_up.py
@@ -16,13 +16,12 @@ import hashlib
 import uuid
 import datetime
 
-from aiomysql import Connection, Cursor
+from aiomysql import Connection
 
-from plugin_types.integration_db import IntegrationDatabase
 from plugin_types.auth.sign_up import AbstractSignUpToken
 
 
-class SignUpToken(AbstractSignUpToken[IntegrationDatabase[Connection, Cursor]]):
+class SignUpToken(AbstractSignUpToken[Connection]):
     """
     Note: the class methods do not handle transactions - it's up to the calling method
     """

--- a/lib/plugins/mysql_auth/sign_up.py
+++ b/lib/plugins/mysql_auth/sign_up.py
@@ -12,14 +12,17 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 
-from plugin_types.auth.sign_up import AbstractSignUpToken
-from mysql.connector.connection import MySQLConnection
 import hashlib
 import uuid
 import datetime
 
+from aiomysql import Connection, Cursor
 
-class SignUpToken(AbstractSignUpToken[MySQLConnection]):
+from plugin_types.integration_db import IntegrationDatabase
+from plugin_types.auth.sign_up import AbstractSignUpToken
+
+
+class SignUpToken(AbstractSignUpToken[IntegrationDatabase[Connection, Cursor]]):
     """
     Note: the class methods do not handle transactions - it's up to the calling method
     """

--- a/lib/plugins/mysql_corparch/__init__.py
+++ b/lib/plugins/mysql_corparch/__init__.py
@@ -22,8 +22,8 @@ from collections import OrderedDict, defaultdict
 import logging
 from typing import Dict, List, Tuple, Iterable
 import json
-from mysql.connector.connection import MySQLConnection
-from mysql.connector.cursor import MySQLCursor
+
+from aiomysql import Connection, Cursor
 from sanic.blueprints import Blueprint
 
 from action.decorators import http_action
@@ -377,12 +377,13 @@ class MySQLCorparch(AbstractSearchableCorporaArchive):
 
 
 @inject(plugins.runtime.USER_ITEMS, plugins.runtime.INTEGRATION_DB)
-def create_instance(conf, user_items, integ_db: IntegrationDatabase[MySQLConnection, MySQLCursor]):
+def create_instance(conf, user_items, integ_db: IntegrationDatabase[Connection, Cursor]):
     plugin_conf = conf.get('plugins', 'corparch')
     if integ_db.is_active and 'mysql_host' not in plugin_conf:
         logging.getLogger(__name__).info(f'mysql_corparch uses integration_db[{integ_db.info}]')
         db_backend = Backend(integ_db)
     else:
+        raise NotImplementedError('Asynchronous MySQLOps not implemented yet')
         from plugins.common.mysql import MySQLOps, MySQLConf
         logging.getLogger(__name__).info(
             'mysql_user_items uses custom database configuration {}@{}'.format(

--- a/lib/plugins/mysql_corparch/__init__.py
+++ b/lib/plugins/mysql_corparch/__init__.py
@@ -188,13 +188,13 @@ class MySQLCorparch(AbstractSearchableCorporaArchive):
                               keywords=keywords)
 
     async def list_corpora(self, plugin_ctx, substrs=None, keywords=None, min_size=0, max_size=None, requestable=False,
-                     offset=0, limit=-1, favourites=()):
+                           offset=0, limit=-1, favourites=()):
         user_id = plugin_ctx.user_dict['id']
         ans = OrderedDict()
         for row in await self._backend.list_corpora(
-            user_id, substrs=substrs, keywords=keywords, min_size=min_size,
-            max_size=max_size, requestable=requestable, offset=offset,
-            limit=limit, favourites=favourites):
+                user_id, substrs=substrs, keywords=keywords, min_size=min_size,
+                max_size=max_size, requestable=requestable, offset=offset,
+                limit=limit, favourites=favourites):
             ans[row['id']] = self.corpus_list_item_from_row(plugin_ctx, row)
         return ans
 
@@ -377,7 +377,7 @@ class MySQLCorparch(AbstractSearchableCorporaArchive):
 
 
 @inject(plugins.runtime.USER_ITEMS, plugins.runtime.INTEGRATION_DB)
-def create_instance(conf, user_items, integ_db: IntegrationDatabase[Connection, Cursor]):
+def create_instance(conf, user_items, integ_db: IntegrationDatabase):
     plugin_conf = conf.get('plugins', 'corparch')
     if integ_db.is_active and 'mysql_host' not in plugin_conf:
         logging.getLogger(__name__).info(f'mysql_corparch uses integration_db[{integ_db.info}]')

--- a/lib/plugins/mysql_corparch/__init__.py
+++ b/lib/plugins/mysql_corparch/__init__.py
@@ -23,16 +23,15 @@ import logging
 from typing import Dict, List, Tuple, Iterable
 import json
 
-from aiomysql import Connection, Cursor
 from sanic.blueprints import Blueprint
 
 from action.decorators import http_action
 from action.model.authorized import UserActionModel
+from plugins.mysql_integration_db import MySqlIntegrationDb
 import plugins
 from plugins import inject
 from plugin_types.corparch import AbstractSearchableCorporaArchive, CorpusListItem
 from plugin_types.corparch.backend import DatabaseBackend
-from plugin_types.integration_db import IntegrationDatabase
 from plugin_types.corparch.corpus import (
     BrokenCorpusInfo, TokenConnect, KwicConnect, QuerySuggest, CorpusInfo, StructAttrInfo)
 from plugins.mysql_corparch.backend import Backend
@@ -377,7 +376,7 @@ class MySQLCorparch(AbstractSearchableCorporaArchive):
 
 
 @inject(plugins.runtime.USER_ITEMS, plugins.runtime.INTEGRATION_DB)
-def create_instance(conf, user_items, integ_db: IntegrationDatabase):
+def create_instance(conf, user_items, integ_db: MySqlIntegrationDb):
     plugin_conf = conf.get('plugins', 'corparch')
     if integ_db.is_active and 'mysql_host' not in plugin_conf:
         logging.getLogger(__name__).info(f'mysql_corparch uses integration_db[{integ_db.info}]')

--- a/lib/plugins/mysql_corparch/backend.py
+++ b/lib/plugins/mysql_corparch/backend.py
@@ -23,8 +23,7 @@ from typing import Any, Dict, Iterable, List, Tuple, Union, Optional
 from plugin_types.auth import CorpusAccess
 from plugin_types.integration_db import IntegrationDatabase
 from plugins.common.mysql import MySQLOps
-from mysql.connector.connection import MySQLConnection
-from mysql.connector.cursor import MySQLCursor
+from aiomysql import Connection, Cursor
 
 from plugin_types.corparch.corpus import TagsetInfo, PosCategoryItem
 from plugin_types.corparch.backend import DatabaseBackend
@@ -50,7 +49,7 @@ class Backend(DatabaseBackend):
 
     def __init__(
             self,
-            db: Union[IntegrationDatabase[MySQLConnection, MySQLCursor], MySQLOps],
+            db: Union[IntegrationDatabase[Connection, Cursor], MySQLOps],
             user_table: str = DFLT_USER_TABLE,
             corp_table: str = DFLT_CORP_TABLE,
             corp_id_attr: str = DFLT_CORP_ID_ATTR,
@@ -70,72 +69,72 @@ class Backend(DatabaseBackend):
         self._group_acc_group_attr = group_acc_group_attr
 
     async def contains_corpus(self, corpus_id: str) -> bool:
-        cursor = self._db.cursor()
-        await cursor.execute(f'SELECT name FROM {self._corp_table} WHERE name = %s', (corpus_id,))
-        return cursor.fetchone() is not None
+        async with self._db.cursor() as cursor:
+            await cursor.execute(f'SELECT name FROM {self._corp_table} WHERE name = %s', (corpus_id,))
+            return (await cursor.fetchone()) is not None
 
     async def load_corpus_articles(self, corpus_id: str) -> Iterable[Dict[str, Any]]:
-        cursor = self._db.cursor()
-        await cursor.execute(
-            'SELECT ca.role, a.entry '
-            'FROM kontext_article AS a '
-            'JOIN kontext_corpus_article AS ca ON ca.article_id = a.id '
-            'WHERE ca.corpus_name = %s', (corpus_id,))
-        return cursor.fetchall()
+        async with self._db.cursor() as cursor:
+            await cursor.execute(
+                'SELECT ca.role, a.entry '
+                'FROM kontext_article AS a '
+                'JOIN kontext_corpus_article AS ca ON ca.article_id = a.id '
+                'WHERE ca.corpus_name = %s', (corpus_id,))
+            return await cursor.fetchall()
 
     async def load_all_keywords(self) -> Iterable[Dict[str, str]]:
-        cursor = self._db.cursor()
-        await cursor.execute(
-            'SELECT id, label_cs, label_en, color FROM kontext_keyword ORDER BY display_order')
-        return cursor.fetchall()
+        async with self._db.cursor() as cursor:
+            await cursor.execute(
+                'SELECT id, label_cs, label_en, color FROM kontext_keyword ORDER BY display_order')
+            return await cursor.fetchall()
 
     async def load_ttdesc(self, desc_id) -> Iterable[Dict[str, str]]:
-        cursor = self._db.cursor()
-        await cursor.execute('SELECT text_cs, text_en FROM kontext_ttdesc WHERE id = %s', (desc_id,))
-        return cursor.fetchall()
+        async with self._db.cursor() as cursor:
+            await cursor.execute('SELECT text_cs, text_en FROM kontext_ttdesc WHERE id = %s', (desc_id,))
+            return await cursor.fetchall()
 
     async def load_corpora_descriptions(self, corp_ids: List[str], user_lang: str) -> Dict[str, str]:
         if len(corp_ids) == 0:
             return {}
-        cursor = self._db.cursor()
         placeholders = ', '.join(['%s'] * len(corp_ids))
         col = 'description_{0}'.format(user_lang[:2])
-        await cursor.execute(
-            f'SELECT name AS corpname, {col} AS contents '
-            f'FROM {self._corp_table} '
-            f'WHERE name IN ({placeholders})', corp_ids)
-        return dict((r['corpname'], r['contents']) for r in cursor.fetchall())
+        async with self._db.cursor() as cursor:
+            await cursor.execute(
+                f'SELECT name AS corpname, {col} AS contents '
+                f'FROM {self._corp_table} '
+                f'WHERE name IN ({placeholders})', corp_ids)
+            return {r['corpname']: r['contents'] async for r in cursor}
 
     async def load_corpus(self, corp_id: str) -> Dict[str, Any]:
-        cursor = self._db.cursor()
-        await cursor.execute(
-            'SELECT c.name as id, c.web, cs.name AS sentence_struct, c.collator_locale, '
-            'IF (c.speaker_id_struct IS NOT NULL, CONCAT(c.speaker_id_struct, \'.\', c.speaker_id_attr), NULL) '
-            '  AS speaker_id_attr, '
-            'IF (c.speech_overlap_struct IS NOT NULL AND c.speech_overlap_attr IS NOT NULL, '
-            '    CONCAT(c.speech_overlap_struct, \'.\', c.speech_overlap_attr), '
-            '    c.speech_overlap_struct) AS speech_overlap_attr, '
-            'c.speech_overlap_val, c.use_safe_font, '
-            'c.requestable, c.featured, c.text_types_db AS `database`, '
-            'c.description_cs, c.description_en, '
-            'IF (c.bib_label_attr IS NOT NULL, CONCAT(c.bib_label_struct, \'.\', c.bib_label_attr), NULL) '
-            '  AS label_attr, '
-            'IF (c.bib_id_attr IS NOT NULL, CONCAT(c.bib_id_struct, \'.\', c.bib_id_attr), NULL) AS id_attr, '
-            'IF (c.speech_segment_attr IS NOT NULL, CONCAT(c.speech_segment_struct, \'.\', c.speech_segment_attr), '
-            '  NULL) AS speech_segment, '
-            'c.bib_group_duplicates, c.description_cs, c.description_en, '
-            'c.ttdesc_id AS ttdesc_id, GROUP_CONCAT(kc.keyword_id, \',\') AS keywords, '
-            'c.size, rc.name, rc.rencoding AS encoding, rc.language, '
-            'c.default_virt_keyboard as default_virt_keyboard, '
-            'c.default_view_opts, c.default_tagset '
-            f'FROM {self._corp_table} AS c '
-            'LEFT JOIN kontext_keyword_corpus AS kc ON kc.corpus_name = c.name '
-            'LEFT JOIN registry_conf AS rc ON rc.corpus_name = c.name '
-            'LEFT JOIN corpus_structure AS cs ON cs.corpus_name = kc.corpus_name '
-            '  AND c.sentence_struct = cs.name '
-            'WHERE c.active = 1 AND c.name = %s '
-            'GROUP BY c.name ', (corp_id,))
-        return cursor.fetchone()
+        async with self._db.cursor() as cursor:
+            await cursor.execute(
+                'SELECT c.name as id, c.web, cs.name AS sentence_struct, c.collator_locale, '
+                'IF (c.speaker_id_struct IS NOT NULL, CONCAT(c.speaker_id_struct, \'.\', c.speaker_id_attr), NULL) '
+                '  AS speaker_id_attr, '
+                'IF (c.speech_overlap_struct IS NOT NULL AND c.speech_overlap_attr IS NOT NULL, '
+                '    CONCAT(c.speech_overlap_struct, \'.\', c.speech_overlap_attr), '
+                '    c.speech_overlap_struct) AS speech_overlap_attr, '
+                'c.speech_overlap_val, c.use_safe_font, '
+                'c.requestable, c.featured, c.text_types_db AS `database`, '
+                'c.description_cs, c.description_en, '
+                'IF (c.bib_label_attr IS NOT NULL, CONCAT(c.bib_label_struct, \'.\', c.bib_label_attr), NULL) '
+                '  AS label_attr, '
+                'IF (c.bib_id_attr IS NOT NULL, CONCAT(c.bib_id_struct, \'.\', c.bib_id_attr), NULL) AS id_attr, '
+                'IF (c.speech_segment_attr IS NOT NULL, CONCAT(c.speech_segment_struct, \'.\', c.speech_segment_attr), '
+                '  NULL) AS speech_segment, '
+                'c.bib_group_duplicates, c.description_cs, c.description_en, '
+                'c.ttdesc_id AS ttdesc_id, GROUP_CONCAT(kc.keyword_id, \',\') AS keywords, '
+                'c.size, rc.name, rc.rencoding AS encoding, rc.language, '
+                'c.default_virt_keyboard as default_virt_keyboard, '
+                'c.default_view_opts, c.default_tagset '
+                f'FROM {self._corp_table} AS c '
+                'LEFT JOIN kontext_keyword_corpus AS kc ON kc.corpus_name = c.name '
+                'LEFT JOIN registry_conf AS rc ON rc.corpus_name = c.name '
+                'LEFT JOIN corpus_structure AS cs ON cs.corpus_name = kc.corpus_name '
+                '  AND c.sentence_struct = cs.name '
+                'WHERE c.active = 1 AND c.name = %s '
+                'GROUP BY c.name ', (corp_id,))
+            return await cursor.fetchone()
 
     async def list_corpora(
             self, user_id, substrs=None, keywords=None, min_size=0, max_size=None, requestable=False,
@@ -185,7 +184,6 @@ class Backend(DatabaseBackend):
         values_cond1.append(len(keywords) if keywords else 0)  # for num_match_keys >= x
         values_cond2.append(len(keywords) if keywords else 0)  # for num_match_keys >= x
 
-        c = self._db.cursor()
         # performance note: using UNION instead of 'WHERE user_id = x OR c.requestable = 1' increased
         # mysql performance significantly (more than 10x faster).
         sql = ('SELECT IF(count(*) = MAX(requestable), 1, 0) AS requestable, id, web, collator_locale, '
@@ -249,19 +247,20 @@ class Backend(DatabaseBackend):
             'ORDER BY g_name, version DESC, id '
             'LIMIT %s '
             'OFFSET %s')
-        await c.execute(sql, where + [limit, offset])
-        return c.fetchall()
+        async with self._db.cursor() as cursor:
+            await cursor.execute(sql, where + [limit, offset])
+            return await cursor.fetchall()
 
     async def load_featured_corpora(self, user_lang: str) -> Iterable[Dict[str, str]]:
-        cursor = self._db.cursor()
         desc_col = 'c.description_{0}'.format(user_lang[:2])
-        await cursor.execute(
-            'SELECT c.name AS corpus_id, c.name AS id, ifnull(rc.name, c.name) AS name, '
-            f'{desc_col} AS description, c.size '
-            f'FROM {self._corp_table} AS c '
-            'LEFT JOIN registry_conf AS rc ON rc.corpus_name = c.name '
-            'WHERE c.active = 1 AND c.featured = 1 ORDER BY c.name')
-        return cursor.fetchall()
+        async with self._db.cursor() as cursor:
+            await cursor.execute(
+                'SELECT c.name AS corpus_id, c.name AS id, ifnull(rc.name, c.name) AS name, '
+                f'{desc_col} AS description, c.size '
+                f'FROM {self._corp_table} AS c '
+                'LEFT JOIN registry_conf AS rc ON rc.corpus_name = c.name '
+                'WHERE c.active = 1 AND c.featured = 1 ORDER BY c.name')
+            return await cursor.fetchall()
 
     async def load_registry_table(self, corpus_id: str, variant: str) -> Dict[str, str]:
         cols = (['rc.{0} AS {1}'.format(v, k) for k, v in list(REG_COLS_MAP.items())] +
@@ -278,167 +277,167 @@ class Backend(DatabaseBackend):
                 'JOIN registry_variable AS rv ON rv.corpus_name = rc.corpus_name AND rv.variant IS NULL '
                 'WHERE rc.corpus_name = %s').format(', '.join(cols))
             vals = (corpus_id, )
-        cursor = self._db.cursor()
-        await cursor.execute(sql, vals)
-        return cursor.fetchone()
+        async with self._db.cursor() as cursor:
+            await cursor.execute(sql, vals)
+            return await cursor.fetchone()
 
     async def load_corpus_posattrs(self, corpus_id: str) -> Iterable[Dict[str, Any]]:
         sql = 'SELECT {0} FROM corpus_posattr WHERE corpus_name = %s ORDER BY position'.format(
             ', '.join(['name', 'position'] + ['`{0}` AS `{1}`'.format(v, k) for k, v in list(POS_COLS_MAP.items())]))
-        cursor = self._db.cursor()
-        await cursor.execute(sql, (corpus_id,))
-        return cursor.fetchall()
+        async with self._db.cursor() as cursor:
+            await cursor.execute(sql, (corpus_id,))
+            return await cursor.fetchall()
 
     async def load_corpus_posattr_references(self, corpus_id: str, posattr_id: str) -> Tuple[str, str]:
-        cursor = self._db.cursor()
-        await cursor.execute(
-            'SELECT r2.name AS n1, r3.name AS n2 '
-            'FROM corpus_posattr AS r1 '
-            'LEFT JOIN corpus_posattr AS r2 ON r1.fromattr = r2.name '
-            'LEFT JOIN corpus_posattr AS r3 ON r1.mapto = r3.name '
-            'WHERE r1.corpus_name = %s AND r1.name = %s', (corpus_id, posattr_id))
-        ans = cursor.fetchone()
+        async with self._db.cursor() as cursor:
+            await cursor.execute(
+                'SELECT r2.name AS n1, r3.name AS n2 '
+                'FROM corpus_posattr AS r1 '
+                'LEFT JOIN corpus_posattr AS r2 ON r1.fromattr = r2.name '
+                'LEFT JOIN corpus_posattr AS r3 ON r1.mapto = r3.name '
+                'WHERE r1.corpus_name = %s AND r1.name = %s', (corpus_id, posattr_id))
+            ans = await cursor.fetchone()
         return (ans['n1'], ans['n2']) if ans is not None else (None, None)
 
     async def load_corpus_alignments(self, corpus_id: str) -> List[str]:
-        cursor = self._db.cursor()
-        await cursor.execute(
-            'SELECT ca.corpus_name_2 AS id '
-            'FROM corpus_alignment AS ca '
-            'WHERE ca.corpus_name_1 = %s', (corpus_id,))
-        return [row['id'] for row in cursor.fetchall()]
+        async with self._db.cursor() as cursor:
+            await cursor.execute(
+                'SELECT ca.corpus_name_2 AS id '
+                'FROM corpus_alignment AS ca '
+                'WHERE ca.corpus_name_1 = %s', (corpus_id,))
+            return [row['id'] async for row in cursor]
 
     async def load_corpus_structures(self, corpus_id: str) -> Iterable[Dict[str, Any]]:
         cols = ['name'] + ['`{0}` AS `{1}`'.format(v, k)
                            for k, v in list(STRUCT_COLS_MAP.items())]
         sql = 'SELECT {0} FROM corpus_structure WHERE corpus_name = %s'.format(', '.join(cols))
-        cursor = self._db.cursor()
-        await cursor.execute(sql, (corpus_id,))
-        return cursor.fetchall()
+        async with self._db.cursor() as cursor:
+            await cursor.execute(sql, (corpus_id,))
+            return await cursor.fetchall()
 
     async def load_corpus_structattrs(self, corpus_id: str, structure_id: Optional[str] = None) -> Iterable[Dict[str, Any]]:
-        cursor = self._db.cursor()
-        if structure_id:
-            sql = (
-                'SELECT {0}, dt_format, structure_name, name '
-                'FROM corpus_structattr WHERE corpus_name = %s AND structure_name = %s').format(
+        async with self._db.cursor() as cursor:
+            if structure_id:
+                sql = (
+                    'SELECT {0}, dt_format, structure_name, name '
+                    'FROM corpus_structattr WHERE corpus_name = %s AND structure_name = %s').format(
+                        ', '.join(['name'] + ['`{0}` AS `{1}`'.format(v, k) for k, v in list(SATTR_COLS_MAP.items())]))
+                await cursor.execute(sql, (corpus_id, structure_id))
+            else:
+                sql = 'SELECT {0}, dt_format, structure_name, name FROM corpus_structattr WHERE corpus_name = %s'.format(
                     ', '.join(['name'] + ['`{0}` AS `{1}`'.format(v, k) for k, v in list(SATTR_COLS_MAP.items())]))
-            await cursor.execute(sql, (corpus_id, structure_id))
-        else:
-            sql = 'SELECT {0}, dt_format, structure_name, name FROM corpus_structattr WHERE corpus_name = %s'.format(
-                ', '.join(['name'] + ['`{0}` AS `{1}`'.format(v, k) for k, v in list(SATTR_COLS_MAP.items())]))
-            await cursor.execute(sql, (corpus_id,))
-        return cursor.fetchall()
+                await cursor.execute(sql, (corpus_id,))
+            return await cursor.fetchall()
 
     async def load_subcorpattrs(self, corpus_id: str) -> List[str]:
-        cursor = self._db.cursor()
-        await cursor.execute(
-            'SELECT cs.structure_name AS struct, cs.name AS structattr '
-            'FROM corpus_structattr AS cs '
-            'WHERE cs.subcorpattrs_idx > -1 AND cs.corpus_name = %s '
-            'ORDER BY cs.subcorpattrs_idx', (corpus_id,))
-        return ['{0}.{1}'.format(x['struct'], x['structattr']) for x in cursor.fetchall()]
+        async with self._db.cursor() as cursor:
+            await cursor.execute(
+                'SELECT cs.structure_name AS struct, cs.name AS structattr '
+                'FROM corpus_structattr AS cs '
+                'WHERE cs.subcorpattrs_idx > -1 AND cs.corpus_name = %s '
+                'ORDER BY cs.subcorpattrs_idx', (corpus_id,))
+            return ['{0}.{1}'.format(x['struct'], x['structattr']) async for x in cursor]
 
     async def load_freqttattrs(self, corpus_id: str) -> List[str]:
-        cursor = self._db.cursor()
-        await cursor.execute(
-            'SELECT cs.structure_name AS struct, cs.name AS structattr '
-            'FROM corpus_structattr AS cs '
-            'WHERE cs.freqttattrs_idx > -1 AND cs.corpus_name = %s '
-            'ORDER BY cs.freqttattrs_idx', (corpus_id,))
-        return ['{0}.{1}'.format(x['struct'], x['structattr']) for x in cursor.fetchall()]
+        async with self._db.cursor() as cursor:
+            await cursor.execute(
+                'SELECT cs.structure_name AS struct, cs.name AS structattr '
+                'FROM corpus_structattr AS cs '
+                'WHERE cs.freqttattrs_idx > -1 AND cs.corpus_name = %s '
+                'ORDER BY cs.freqttattrs_idx', (corpus_id,))
+            return ['{0}.{1}'.format(x['struct'], x['structattr']) async for x in cursor]
 
     async def load_tckc_providers(self, corpus_id: str) -> Iterable[Dict[str, Any]]:
-        cursor = self._db.cursor()
-        await cursor.execute(
-            'SELECT provider, type, is_kwic_view FROM kontext_tckc_corpus WHERE corpus_name = %s ORDER BY display_order',
-            (corpus_id,))
-        return cursor.fetchall()
+        async with self._db.cursor() as cursor:
+            await cursor.execute(
+                'SELECT provider, type, is_kwic_view FROM kontext_tckc_corpus WHERE corpus_name = %s ORDER BY display_order',
+                (corpus_id,))
+            return await cursor.fetchall()
 
     async def corpus_access(self, user_id: str, corpus_id: str) -> CorpusAccess:
-        cursor = self._db.cursor()
-        await cursor.execute(
-            'SELECT %s AS user_id, c.name AS corpus_id, IF (ucp.limited = 1, \'omezeni\', NULL) AS variant '
-            'FROM ( '
-            f'  SELECT {self._user_acc_table}.{self._user_acc_corp_attr} AS corpus_id, '
-            f'    {self._user_acc_table}.limited AS limited '
-            f'  FROM {self._user_acc_table} WHERE ({self._user_acc_table}.user_id = %s) '
-            '  UNION '
-            f'  SELECT {self._group_acc_table}.{self._group_acc_corp_attr} AS corpus_id, '
-            f'    {self._group_acc_table}.limited AS limited '
-            f'  FROM {self._group_acc_table} '
-            f'  WHERE ({self._group_acc_table}.{self._group_acc_group_attr} = '
-            f'      (SELECT {self._user_table}.{self._group_acc_group_attr} '
-            f'           FROM {self._user_table} WHERE ({self._user_table}.id = %s))) '
-            ') as ucp '
-            f'JOIN {self._corp_table} AS c ON ucp.corpus_id = c.id AND c.name = %s '
-            'ORDER BY ucp.limited LIMIT 1',
-            (user_id, user_id, user_id, corpus_id))
-        row = cursor.fetchone()
+        async with self._db.cursor() as cursor:
+            await cursor.execute(
+                'SELECT %s AS user_id, c.name AS corpus_id, IF (ucp.limited = 1, \'omezeni\', NULL) AS variant '
+                'FROM ( '
+                f'  SELECT {self._user_acc_table}.{self._user_acc_corp_attr} AS corpus_id, '
+                f'    {self._user_acc_table}.limited AS limited '
+                f'  FROM {self._user_acc_table} WHERE ({self._user_acc_table}.user_id = %s) '
+                '  UNION '
+                f'  SELECT {self._group_acc_table}.{self._group_acc_corp_attr} AS corpus_id, '
+                f'    {self._group_acc_table}.limited AS limited '
+                f'  FROM {self._group_acc_table} '
+                f'  WHERE ({self._group_acc_table}.{self._group_acc_group_attr} = '
+                f'      (SELECT {self._user_table}.{self._group_acc_group_attr} '
+                f'           FROM {self._user_table} WHERE ({self._user_table}.id = %s))) '
+                ') as ucp '
+                f'JOIN {self._corp_table} AS c ON ucp.corpus_id = c.id AND c.name = %s '
+                'ORDER BY ucp.limited LIMIT 1',
+                (user_id, user_id, user_id, corpus_id))
+            row = await cursor.fetchone()
         if not row:
             return CorpusAccess(False, False, '')
         return CorpusAccess(False, True, row['variant'] if row['variant'] else '')
 
     async def get_permitted_corpora(self, user_id: str) -> List[str]:
-        cursor = self._db.cursor()
-        await cursor.execute(
-            'SELECT %s AS user_id, c.name AS corpus_id, IF (ucp.limited = 1, \'omezeni\', NULL) AS variant '
-            'FROM ( '
-            f'  SELECT {self._user_acc_table}.{self._user_acc_corp_attr} AS corpus_id, '
-            f'    {self._user_acc_table}.limited AS limited '
-            f'  FROM {self._user_acc_table} WHERE ({self._user_acc_table}.user_id = %s) '
-            '  UNION '
-            f'  SELECT {self._group_acc_table}.{self._group_acc_corp_attr} AS corpus_id, '
-            f'     {self._group_acc_table}.limited AS limited '
-            f'  FROM {self._group_acc_table} '
-            f'  WHERE ({self._group_acc_table}.{self._group_acc_group_attr} = '
-            f'      (SELECT {self._user_table}.{self._group_acc_group_attr} '
-            f'           FROM {self._user_table} WHERE ({self._user_table}.id = %s))) '
-            ') as ucp '
-            f'JOIN {self._corp_table} AS c ON ucp.corpus_id = c.id', (user_id, user_id, user_id))
-        return [r['corpus_id'] for r in cursor.fetchall()]
+        async with self._db.cursor() as cursor:
+            await cursor.execute(
+                'SELECT %s AS user_id, c.name AS corpus_id, IF (ucp.limited = 1, \'omezeni\', NULL) AS variant '
+                'FROM ( '
+                f'  SELECT {self._user_acc_table}.{self._user_acc_corp_attr} AS corpus_id, '
+                f'    {self._user_acc_table}.limited AS limited '
+                f'  FROM {self._user_acc_table} WHERE ({self._user_acc_table}.user_id = %s) '
+                '  UNION '
+                f'  SELECT {self._group_acc_table}.{self._group_acc_corp_attr} AS corpus_id, '
+                f'     {self._group_acc_table}.limited AS limited '
+                f'  FROM {self._group_acc_table} '
+                f'  WHERE ({self._group_acc_table}.{self._group_acc_group_attr} = '
+                f'      (SELECT {self._user_table}.{self._group_acc_group_attr} '
+                f'           FROM {self._user_table} WHERE ({self._user_table}.id = %s))) '
+                ') as ucp '
+                f'JOIN {self._corp_table} AS c ON ucp.corpus_id = c.id', (user_id, user_id, user_id))
+            return [r['corpus_id'] async for r in cursor]
 
     async def load_corpus_tagsets(self, corpus_id: str) -> List[TagsetInfo]:
-        cursor = self._db.cursor()
-        await cursor.execute(
-            'SELECT ct.corpus_name, ct.pos_attr, ct.feat_attr, t.tagset_type, ct.tagset_name, '
-            'ct.kontext_widget_enabled, t.doc_url_local, t.doc_url_en, '
-            'GROUP_CONCAT(CONCAT_WS(\',\',tpc.tag_search_pattern,tpc.pos) SEPARATOR \',\') AS patterns_pos '
-            'FROM tagset AS t '
-            'JOIN corpus_tagset AS ct ON ct.tagset_name = t.name '
-            'LEFT JOIN tagset_pos_category AS tpc ON ct.tagset_name = tpc.tagset_name '
-            'WHERE ct.corpus_name = %s '
-            'GROUP BY tagset_name', (corpus_id, ))
-        return [
-            TagsetInfo(
-                ident=row['tagset_name'],
-                type=row['tagset_type'],
-                corpus_name=row['corpus_name'],
-                pos_attr=row['pos_attr'],
-                feat_attr=row['feat_attr'],
-                widget_enabled=bool(row['kontext_widget_enabled']),
-                doc_url_local=row['doc_url_local'],
-                doc_url_en=row['doc_url_en'],
-                pos_category=[
-                    PosCategoryItem(*pattern_pos)
-                    for pattern_pos in list(zip(row['patterns_pos'].split(',')[::2], row['patterns_pos'].split(',')[1::2]))
-                    if pattern_pos
-                ]
-            )
-            for row in cursor
-        ]
+        async with self._db.cursor() as cursor:
+            await cursor.execute(
+                'SELECT ct.corpus_name, ct.pos_attr, ct.feat_attr, t.tagset_type, ct.tagset_name, '
+                'ct.kontext_widget_enabled, t.doc_url_local, t.doc_url_en, '
+                'GROUP_CONCAT(CONCAT_WS(\',\',tpc.tag_search_pattern,tpc.pos) SEPARATOR \',\') AS patterns_pos '
+                'FROM tagset AS t '
+                'JOIN corpus_tagset AS ct ON ct.tagset_name = t.name '
+                'LEFT JOIN tagset_pos_category AS tpc ON ct.tagset_name = tpc.tagset_name '
+                'WHERE ct.corpus_name = %s '
+                'GROUP BY tagset_name', (corpus_id, ))
+            return [
+                TagsetInfo(
+                    ident=row['tagset_name'],
+                    type=row['tagset_type'],
+                    corpus_name=row['corpus_name'],
+                    pos_attr=row['pos_attr'],
+                    feat_attr=row['feat_attr'],
+                    widget_enabled=bool(row['kontext_widget_enabled']),
+                    doc_url_local=row['doc_url_local'],
+                    doc_url_en=row['doc_url_en'],
+                    pos_category=[
+                        PosCategoryItem(*pattern_pos)
+                        for pattern_pos in list(zip(row['patterns_pos'].split(',')[::2], row['patterns_pos'].split(',')[1::2]))
+                        if pattern_pos
+                    ]
+                )
+                async for row in cursor
+            ]
 
     async def load_interval_attrs(self, corpus_id):
-        cursor = self._db.cursor()
-        await cursor.execute(
-            'SELECT interval_struct, interval_attr, widget '
-            'FROM kontext_interval_attr '
-            'WHERE corpus_name = %s', (corpus_id,))
-        return [('{0}.{1}'.format(r['interval_struct'], r['interval_attr']), r['widget']) for r in cursor.fetchall()]
+        async with self._db.cursor() as cursor:
+            await cursor.execute(
+                'SELECT interval_struct, interval_attr, widget '
+                'FROM kontext_interval_attr '
+                'WHERE corpus_name = %s', (corpus_id,))
+            return [('{0}.{1}'.format(r['interval_struct'], r['interval_attr']), r['widget']) async for r in cursor]
 
     async def load_simple_query_default_attrs(self, corpus_id: str) -> List[str]:
-        cursor = self._db.cursor()
-        await cursor.execute(
-            'SELECT pos_attr FROM kontext_simple_query_default_attrs WHERE corpus_name = %s',
-            (corpus_id,))
-        return [r['pos_attr'] for r in cursor.fetchall()]
+        async with self._db.cursor() as cursor:
+            await cursor.execute(
+                'SELECT pos_attr FROM kontext_simple_query_default_attrs WHERE corpus_name = %s',
+                (corpus_id,))
+            return [r['pos_attr'] async for r in cursor]

--- a/lib/plugins/mysql_corparch/backend.py
+++ b/lib/plugins/mysql_corparch/backend.py
@@ -20,10 +20,9 @@
 A corparch database backend for MySQL/MariaDB for 'read' operations
 """
 from typing import Any, Dict, Iterable, List, Tuple, Union, Optional
+from plugins.mysql_integration_db import MySqlIntegrationDb
 from plugin_types.auth import CorpusAccess
-from plugin_types.integration_db import IntegrationDatabase
 from plugins.common.mysql import MySQLOps
-from aiomysql import Connection, Cursor
 
 from plugin_types.corparch.corpus import TagsetInfo, PosCategoryItem
 from plugin_types.corparch.backend import DatabaseBackend
@@ -49,7 +48,7 @@ class Backend(DatabaseBackend):
 
     def __init__(
             self,
-            db: Union[IntegrationDatabase[Connection, Cursor], MySQLOps],
+            db: Union[MySqlIntegrationDb, MySQLOps],
             user_table: str = DFLT_USER_TABLE,
             corp_table: str = DFLT_CORP_TABLE,
             corp_id_attr: str = DFLT_CORP_ID_ATTR,

--- a/lib/plugins/mysql_integration_db/__init__.py
+++ b/lib/plugins/mysql_integration_db/__init__.py
@@ -16,81 +16,22 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
+from dataclasses import dataclass, asdict
 from plugin_types.integration_db import IntegrationDatabase
-from mysql.connector.connection import MySQLConnection
-from mysql.connector.cursor import MySQLCursor
-from mysql.connector.errors import OperationalError
-from mysql.connector import connect
-import logging
-import time
-from util import as_async
 from typing import Dict, Optional
+import aiomysql
 
 
-class MySQLAsyncCursor:
-
-    def __init__(self, cur: MySQLCursor):
-        self._cur = cur
-
-    def next(self):
-        return self._cur.next()
-
-    def __next__(self):
-        return self._cur.__next__()
-
-    def __iter__(self):
-        return self._cur.__iter__()
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        self._cur.close()
-
-    def close(self):
-        return self._cur.close()
-
-    @as_async
-    def execute(self, operation, params=None, multi=False):
-        return self._cur.execute(operation, params, multi)
-
-    @as_async
-    def executemany(self, operation, seq_params):
-        return self._cur.executemany(operation, seq_params)
-
-    def stored_results(self):
-        return self._cur.stored_results()
-
-    @as_async
-    def callproc(self, procname, args=()):
-        return self._cur.callproc(procname, args)
-
-    def getlastrowid(self):
-        return self._cur.getlastrowid()
-
-    def fetchone(self):
-        return self._cur.fetchone()
-
-    def fetchmany(self, size=None):
-        return self._cur.fetchmany(size)
-
-    def fetchall(self):
-        return self._cur.fetchall()
-
-    @property
-    def column_names(self):
-        return self._cur.column_names
-
-    @property
-    def statement(self):
-        return self._cur.statement
-
-    @property
-    def with_rows(self):
-        return self._cur.with_rows
+@dataclass
+class ConnectionArgs:
+    host: str
+    db: str
+    user: str
+    password: str
+    autocommit: bool
 
 
-class MySqlIntegrationDb(IntegrationDatabase[MySQLConnection, MySQLCursor]):
+class MySqlIntegrationDb(IntegrationDatabase[aiomysql.Connection, aiomysql.Cursor]):
     """
     MySqlIntegrationDb is a variant of integration_db plug-in providing access
     to MySQL/MariaDB instances. It is recommended for:
@@ -104,9 +45,9 @@ class MySqlIntegrationDb(IntegrationDatabase[MySQLConnection, MySQLCursor]):
     is done automatically.
     """
 
-    _conn: Optional[MySQLConnection]
+    _conn: Optional[aiomysql.Connection]
 
-    _conn_args: Dict[str, str]
+    _conn_args: ConnectionArgs
 
     _retry_delay: int
 
@@ -114,40 +55,23 @@ class MySqlIntegrationDb(IntegrationDatabase[MySQLConnection, MySQLCursor]):
 
     def __init__(self, host, database, user, password, pool_size, pool_name, autocommit, retry_delay, retry_attempts,
                  environment_wait_sec: int):
-        self._conn_args = dict(
-            host=host, database=database, user=user, password=password, pool_size=pool_size,
-            pool_name=pool_name, autocommit=autocommit)
+        self._conn_args = ConnectionArgs(
+            host=host, db=database, user=user, password=password, autocommit=autocommit)
         self._retry_delay = retry_delay
         self._retry_attempts = retry_attempts
         self._environment_wait_sec = environment_wait_sec
         self._conn = None
 
-    @property
-    def connection(self):
+    async def connection(self) -> aiomysql.Connection:
         if self._conn is None:
-            self._conn = connect(**self._conn_args)
+            self._conn = aiomysql.connect(**asdict(self._conn_args))
         return self._conn
 
-    def cursor(self, dictionary=True, buffered=False):
-        try:
-            # TODO buffered overwritten hiere
-            return MySQLAsyncCursor(self.cursor_sync(dictionary, buffered=True))
-        except OperationalError as ex:
-            if 'MySQL Connection not available' in ex.msg:
-                logging.getLogger(__name__).warning(
-                    'Lost connection to MySQL server - reconnecting')
-                self.connection.reconnect(delay=self._retry_delay, attempts=self._retry_attempts)
-                return self.connection.cursor(dictionary=dictionary, buffered=buffered)
-
-    def cursor_sync(self, dictionary=True, buffered=False):
-        try:
-            return self.connection.cursor(dictionary=dictionary, buffered=buffered)
-        except OperationalError as ex:
-            if 'MySQL Connection not available' in ex.msg:
-                logging.getLogger(__name__).warning(
-                    'Lost connection to MySQL server - reconnecting')
-                self.connection.reconnect(delay=self._retry_delay, attempts=self._retry_attempts)
-                return self.connection.cursor(dictionary=dictionary, buffered=buffered)
+    async def cursor(self, dictionary=True, buffered=False) -> aiomysql.Cursor:
+        if dictionary:
+            return await self._conn.cursor(aiomysql.DictCursor)
+        else:
+            return await self._conn.cursor()
 
     @property
     def is_active(self):
@@ -159,47 +83,30 @@ class MySqlIntegrationDb(IntegrationDatabase[MySQLConnection, MySQLCursor]):
 
     @property
     def info(self):
-        return f'{self.connection.server_host}/{self.connection.database}'
+        return f'{self._conn_args.server_host}/{self._conn_args.db}'
 
     def wait_for_environment(self):
-        t0 = time.time()
-        logging.getLogger(__name__).info(
-            'Going to wait {}s for integration environment'.format(self._environment_wait_sec))
-        while (time.time() - t0) < self._environment_wait_sec:
-            try:
-                cursor = self.connection.cursor(dictionary=False, buffered=False)
-                cursor.execute('SELECT COUNT(*) FROM kontext_integration_env LIMIT 1')
-                row = cursor.fetchone()
-                if row and row[0] == 1:
-                    return None
-            except Exception as ex:
-                logging.getLogger(__name__).warning(f'Integration environment still not available. Reason: {ex}')
-            time.sleep(0.5)
-        return Exception(
-            'Unable to confirm integration environment within defined interval {}s.'.format(self._environment_wait_sec),
-            'Please check table kontext_integration_env')
+        None
 
-    @as_async
-    def execute(self, sql, args):
-        cursor = self.cursor(buffered=True)
-        cursor.execute(sql, args)
+    async def execute(self, sql, args) -> aiomysql.Cursor:
+        cursor = await self.cursor(buffered=True)
+        await cursor.execute(sql, args)
         print('##### CURSOR: {}'.format(cursor))
         return cursor
 
-    @as_async
-    def executemany(self, sql, args_rows):
-        cursor = self.cursor()
-        cursor.executemany(sql, args_rows)
+    async def executemany(self, sql, args_rows) -> aiomysql.Cursor:
+        cursor = await self.cursor()
+        await cursor.executemany(sql, args_rows)
         return cursor
 
-    def start_transaction(self, isolation_level=None):
-        return self.connection.start_transaction()
+    async def start_transaction(self, isolation_level=None):
+        await (await self.connection()).begin()
 
-    def commit(self):
-        self.connection.commit()
+    async def commit(self):
+        await (await self.connection()).commit()
 
-    def rollback(self):
-        self.connection.rollback()
+    async def rollback(self):
+        await (await self.connection()).rollback()
 
 
 def create_instance(conf):

--- a/lib/plugins/mysql_query_history/__init__.py
+++ b/lib/plugins/mysql_query_history/__init__.py
@@ -31,8 +31,7 @@ configuration.
 
 from datetime import datetime
 import logging
-from mysql.connector.connection import MySQLConnection
-from mysql.connector.cursor import MySQLCursor
+from aiomysql import Connection, Cursor
 
 from plugin_types.auth import AbstractAuth
 from plugin_types.integration_db import IntegrationDatabase
@@ -68,7 +67,7 @@ class MySqlQueryHistory(AbstractQueryHistory):
     def __init__(
             self,
             conf,
-            db: IntegrationDatabase[MySQLConnection, MySQLCursor],
+            db: IntegrationDatabase[Connection, Cursor],
             query_persistence: AbstractQueryPersistence,
             auth: AbstractAuth):
         """
@@ -89,55 +88,55 @@ class MySqlQueryHistory(AbstractQueryHistory):
         self._auth = auth
         self._page_num_records = int(conf.get('plugins', 'query_history')['page_num_records'])
 
-    def store(self, user_id, query_id, q_supertype):
+    async def store(self, user_id, query_id, q_supertype):
         created = int(datetime.utcnow().timestamp())
-        corpora = self._query_persistence.open(query_id)['corpora']
-        cursor = self._db.cursor()
-        cursor.executemany(
-            f'INSERT IGNORE INTO {self.TABLE_NAME} '
-            '(corpus_name, query_id, user_id, q_supertype, created) VALUES (%s, %s, %s, %s, %s)',
-            [(corpus, query_id, user_id, q_supertype, created) for corpus in corpora]
-        )
+        corpora = (await self._query_persistence.open(query_id))['corpora']
+        async with self._db.cursor() as cursor:
+            await cursor.executemany(
+                f'INSERT IGNORE INTO {self.TABLE_NAME} '
+                '(corpus_name, query_id, user_id, q_supertype, created) VALUES (%s, %s, %s, %s, %s)',
+                [(corpus, query_id, user_id, q_supertype, created) for corpus in corpora]
+            )
         return created
 
-    def _update_name(self, user_id, query_id, created, new_name) -> bool:
-        cursor = self._db.cursor()
-        cursor.execute(
-            f'UPDATE {self.TABLE_NAME} '
-            'SET name = %s '
-            'WHERE user_id = %s AND query_id = %s AND created = %s',
-            (new_name, user_id, query_id, created)
-        )
-        self._db.commit()
-        return cursor.rowcount > 0
+    async def _update_name(self, user_id, query_id, created, new_name) -> bool:
+        async with self._db.cursor() as cursor:
+            await cursor.execute(
+                f'UPDATE {self.TABLE_NAME} '
+                'SET name = %s '
+                'WHERE user_id = %s AND query_id = %s AND created = %s',
+                (new_name, user_id, query_id, created)
+            )
+            self._db.commit()
+            return cursor.rowcount > 0
 
-    def make_persistent(self, user_id, query_id, q_supertype, created, name) -> bool:
-        if self._update_name(user_id, query_id, created, name):
-            self._query_persistence.archive(user_id, query_id)
+    async def make_persistent(self, user_id, query_id, q_supertype, created, name) -> bool:
+        if await self._update_name(user_id, query_id, created, name):
+            await self._query_persistence.archive(user_id, query_id)
         else:
-            c = self.store(user_id, query_id, q_supertype)
-            self._update_name(user_id, query_id, c, name)
+            c = await self.store(user_id, query_id, q_supertype)
+            await self._update_name(user_id, query_id, c, name)
         return True
 
-    def make_transient(self, user_id, query_id, created, name) -> bool:
-        return self._update_name(user_id, query_id, created, None)
+    async def make_transient(self, user_id, query_id, created, name) -> bool:
+        return await self._update_name(user_id, query_id, created, None)
 
-    def delete(self, user_id, query_id, created):
-        cursor = self._db.cursor()
-        cursor.execute(
-            f'DELETE FROM {self.TABLE_NAME} WHERE user_id = %s AND query_id = %s AND created = %s',
-            (user_id, query_id, created)
-        )
-        self._db.commit()
-        return cursor.rowcount
+    async def delete(self, user_id, query_id, created):
+        async with self._db.cursor() as cursor:
+            await cursor.execute(
+                f'DELETE FROM {self.TABLE_NAME} WHERE user_id = %s AND query_id = %s AND created = %s',
+                (user_id, query_id, created)
+            )
+            await self._db.commit()
+            return cursor.rowcount
 
-    def _is_paired_with_conc(self, data) -> bool:
+    async def _is_paired_with_conc(self, data) -> bool:
         q_id = data['query_id']
-        return self._query_persistence.open(q_id) is not None
+        return await self._query_persistence.open(q_id) is not None
 
-    def _merge_conc_data(self, data):
+    async def _merge_conc_data(self, data):
         q_id = data['query_id']
-        edata = self._query_persistence.open(q_id)
+        edata = await self._query_persistence.open(q_id)
 
         def get_ac_val(data, name, corp): return data[name][corp] if name in data else None
 
@@ -178,7 +177,7 @@ class MySqlQueryHistory(AbstractQueryHistory):
         else:
             return None   # persistent result not available
 
-    def get_user_queries(
+    async def get_user_queries(
             self, user_id, corpus_manager, from_date=None, to_date=None, q_supertype=None, corpname=None,
             archived_only=False, offset=0, limit=None):
         """
@@ -204,93 +203,93 @@ class MySqlQueryHistory(AbstractQueryHistory):
         if offset:
             values.append(offset)
 
-        cursor = self._db.cursor()
-        cursor.execute(f'''
-            SELECT DISTINCT query_id, created, name, q_supertype FROM {self.TABLE_NAME} WHERE
-            {' AND '.join(where_sql)}
-            ORDER BY created DESC
-            {'LIMIT %s' if limit is not None else ''}
-            {'OFFSET %s' if offset else ''}
-        ''', values)
+        async with self._db.cursor() as cursor:
+            await cursor.execute(f'''
+                SELECT DISTINCT query_id, created, name, q_supertype FROM {self.TABLE_NAME} WHERE
+                {' AND '.join(where_sql)}
+                ORDER BY created DESC
+                {'LIMIT %s' if limit is not None else ''}
+                {'OFFSET %s' if offset else ''}
+            ''', values)
 
-        full_data = []
-        corpora = CorpusCache(corpus_manager)
-        for item in cursor.fetchall():
-            q_supertype = item['q_supertype']
-            if q_supertype == 'conc':
-                tmp = self._merge_conc_data(item)
-                if not tmp:
-                    continue
-                tmp['human_corpname'] = corpora.corpus(tmp['corpname']).get_conf('NAME')
-                for ac in tmp['aligned']:
-                    ac['human_corpname'] = corpora.corpus(ac['corpname']).get_conf('NAME')
-                full_data.append(tmp)
-            elif q_supertype == 'pquery':
-                stored = self._query_persistence.open(item['query_id'])
-                if not stored:
-                    continue
-                tmp = {'corpname': stored['corpora'][0], 'aligned': []}
-                tmp['human_corpname'] = corpora.corpus(tmp['corpname']).get_conf('NAME')
-                q_join = []
+            full_data = []
+            corpora = CorpusCache(corpus_manager)
+            async for item in cursor:
+                q_supertype = item['q_supertype']
+                if q_supertype == 'conc':
+                    tmp = self._merge_conc_data(item)
+                    if not tmp:
+                        continue
+                    tmp['human_corpname'] = corpora.corpus(tmp['corpname']).get_conf('NAME')
+                    for ac in tmp['aligned']:
+                        ac['human_corpname'] = corpora.corpus(ac['corpname']).get_conf('NAME')
+                    full_data.append(tmp)
+                elif q_supertype == 'pquery':
+                    stored = await self._query_persistence.open(item['query_id'])
+                    if not stored:
+                        continue
+                    tmp = {'corpname': stored['corpora'][0], 'aligned': []}
+                    tmp['human_corpname'] = corpora.corpus(tmp['corpname']).get_conf('NAME')
+                    q_join = []
 
-                for q in stored.get('form', {}).get('conc_ids', []):
-                    stored_q = self._query_persistence.open(q)
-                    if stored_q is None:
-                        logging.getLogger(__name__).warning(
-                            'Missing conc for pquery: {}'.format(q))
-                    else:
-                        for qs in stored_q.get('lastop_form', {}).get('curr_queries', {}).values():
-                            q_join.append(f'{{ {qs} }}')
-                q_subset = stored.get('form', {}).get('conc_subset_complements', None)
-                if q_subset is not None:
-                    for q in q_subset.get('conc_ids', []):
-                        max_ratio = q_subset.get('max_non_matching_ratio', 0)
-                        stored_q = self._query_persistence.open(q)
+                    for q in stored.get('form', {}).get('conc_ids', []):
+                        stored_q = await self._query_persistence.open(q)
+                        if stored_q is None:
+                            logging.getLogger(__name__).warning(
+                                'Missing conc for pquery: {}'.format(q))
+                        else:
+                            for qs in stored_q.get('lastop_form', {}).get('curr_queries', {}).values():
+                                q_join.append(f'{{ {qs} }}')
+                    q_subset = stored.get('form', {}).get('conc_subset_complements', None)
+                    if q_subset is not None:
+                        for q in q_subset.get('conc_ids', []):
+                            max_ratio = q_subset.get('max_non_matching_ratio', 0)
+                            stored_q = await self._query_persistence.open(q)
+                            if stored_q is None or 'query' not in stored_q.get('lastop_form', {}).get('form_type'):
+                                logging.getLogger(__name__).warning(
+                                    'Missing conc for pquery subset: {}'.format(q))
+                            else:
+                                query = stored_q['lastop_form']['curr_queries'][tmp['corpname']]
+                                q_join.append(f'!{max_ratio if max_ratio else ""}{{ {query} }}')
+
+                    q_superset = stored.get('form', {}).get('conc_superset', None)
+                    if q_superset is not None:
+                        max_ratio = q_superset.get('max_non_matching_ratio', 0)
+                        stored_q = await self._query_persistence.open(q_superset['conc_id'])
                         if stored_q is None or 'query' not in stored_q.get('lastop_form', {}).get('form_type'):
                             logging.getLogger(__name__).warning(
-                                'Missing conc for pquery subset: {}'.format(q))
+                                'Missing conc for pquery superset: {}'.format(q_superset['conc_id']))
                         else:
                             query = stored_q['lastop_form']['curr_queries'][tmp['corpname']]
-                            q_join.append(f'!{max_ratio if max_ratio else ""}{{ {query} }}')
+                            q_join.append(f'?{max_ratio if max_ratio else ""}{{ {query} }}')
 
-                q_superset = stored.get('form', {}).get('conc_superset', None)
-                if q_superset is not None:
-                    max_ratio = q_superset.get('max_non_matching_ratio', 0)
-                    stored_q = self._query_persistence.open(q_superset['conc_id'])
-                    if stored_q is None or 'query' not in stored_q.get('lastop_form', {}).get('form_type'):
-                        logging.getLogger(__name__).warning(
-                            'Missing conc for pquery superset: {}'.format(q_superset['conc_id']))
-                    else:
-                        query = stored_q['lastop_form']['curr_queries'][tmp['corpname']]
-                        q_join.append(f'?{max_ratio if max_ratio else ""}{{ {query} }}')
-
-                tmp['query'] = ' && '.join(q_join)
-                tmp.update(item)
-                tmp.update(stored)
-                full_data.append(tmp)
-            elif q_supertype == 'wlist':
-                stored = self._query_persistence.open(item['query_id'])
-                if not stored:
-                    continue
-                tmp = dict(
-                    corpname=stored['corpora'][0],
-                    aligned=[],
-                    human_corpname=corpora.corpus(stored['corpora'][0]).get_conf('NAME'),
-                    query=stored.get('form', {}).get('wlpat'),
-                    pfilter_words=stored['form']['pfilter_words'],
-                    nfilter_words=stored['form']['nfilter_words'])
-                tmp.update(item)
-                tmp.update(stored)
-                full_data.append(tmp)
-            else:
-                raise ValueError('Unknown query supertype: ', q_supertype)
+                    tmp['query'] = ' && '.join(q_join)
+                    tmp.update(item)
+                    tmp.update(stored)
+                    full_data.append(tmp)
+                elif q_supertype == 'wlist':
+                    stored = await self._query_persistence.open(item['query_id'])
+                    if not stored:
+                        continue
+                    tmp = dict(
+                        corpname=stored['corpora'][0],
+                        aligned=[],
+                        human_corpname=corpora.corpus(stored['corpora'][0]).get_conf('NAME'),
+                        query=stored.get('form', {}).get('wlpat'),
+                        pfilter_words=stored['form']['pfilter_words'],
+                        nfilter_words=stored['form']['nfilter_words'])
+                    tmp.update(item)
+                    tmp.update(stored)
+                    full_data.append(tmp)
+                else:
+                    raise ValueError('Unknown query supertype: ', q_supertype)
 
         for i, item in enumerate(full_data):
             item['idx'] = offset + i
 
         return full_data
 
-    def delete_old_records(self):
+    async def delete_old_records(self):
         """
         Deletes records older than ttl_days. Named records are
         kept intact.
@@ -298,15 +297,14 @@ class MySqlQueryHistory(AbstractQueryHistory):
         now - ttl  > created
         """
         # TODO remove also named but unpaired history entries
-        cursor = self._db.cursor()
-        cursor.execute(
-            f'DELETE FROM {self.TABLE_NAME} WHERE created < %s AND name IS NULL',
-            (int(datetime.utcnow().timestamp()) - self.ttl_days * 3600 * 24,)
-        )
-        self._db.commit()
+        async with self._db.cursor() as cursor:
+            await cursor.execute(
+                f'DELETE FROM {self.TABLE_NAME} WHERE created < %s AND name IS NULL',
+                (int(datetime.utcnow().timestamp()) - self.ttl_days * 3600 * 24,)
+            )
+            await self._db.commit()
 
-    @as_async
-    def export(self, plugin_ctx):
+    async def export(self, plugin_ctx):
         """
         Export plug-in data to dependent HTML pages
         """
@@ -320,7 +318,7 @@ class MySqlQueryHistory(AbstractQueryHistory):
 
 
 @inject(plugins.runtime.INTEGRATION_DB, plugins.runtime.QUERY_PERSISTENCE, plugins.runtime.AUTH)
-def create_instance(settings, db: IntegrationDatabase[MySQLConnection, MySQLCursor], query_persistence, auth):
+def create_instance(settings, db: IntegrationDatabase[Connection, Cursor], query_persistence, auth):
     """
     arguments:
     settings -- the settings.py module

--- a/lib/plugins/mysql_query_history/__init__.py
+++ b/lib/plugins/mysql_query_history/__init__.py
@@ -31,17 +31,15 @@ configuration.
 
 from datetime import datetime
 import logging
-from aiomysql import Connection, Cursor
+from plugins.mysql_integration_db import MySqlIntegrationDb
 
 from plugin_types.auth import AbstractAuth
-from plugin_types.integration_db import IntegrationDatabase
 from corplib.abstract import AbstractKCorpus
 from plugin_types.query_history import AbstractQueryHistory
 from plugins import inject
 import plugins
 from corplib.fallback import EmptyCorpus
 from plugin_types.query_persistence import AbstractQueryPersistence
-from util import as_async
 
 
 class CorpusCache:
@@ -67,7 +65,7 @@ class MySqlQueryHistory(AbstractQueryHistory):
     def __init__(
             self,
             conf,
-            db: IntegrationDatabase[Connection, Cursor],
+            db: MySqlIntegrationDb,
             query_persistence: AbstractQueryPersistence,
             auth: AbstractAuth):
         """
@@ -318,7 +316,7 @@ class MySqlQueryHistory(AbstractQueryHistory):
 
 
 @inject(plugins.runtime.INTEGRATION_DB, plugins.runtime.QUERY_PERSISTENCE, plugins.runtime.AUTH)
-def create_instance(settings, db: IntegrationDatabase[Connection, Cursor], query_persistence, auth):
+def create_instance(settings, db: MySqlIntegrationDb, query_persistence, auth):
     """
     arguments:
     settings -- the settings.py module

--- a/lib/plugins/mysql_query_history/scripts/import.py
+++ b/lib/plugins/mysql_query_history/scripts/import.py
@@ -91,11 +91,12 @@ if __name__ == '__main__':
         print(f'{unique_entries_count} entries will be inserted. ')
         print(f'{len(full_data) - unique_entries_count} duplicate entries will be ignored.')
 
-        cursor = integration_db.cursor()
-        cursor.executemany(
-            'INSERT IGNORE INTO kontext_query_history (user_id, query_id, q_supertype, created, name, corpus_name)'
-            'VALUES (%s, %s, %s, %s, %s, %s)',
-            full_data)
-        integration_db.commit()
+        with integration_db.connection_sync() as conn:
+            with conn.cursor() as cursor:
+                cursor.executemany(
+                    'INSERT IGNORE INTO kontext_query_history (user_id, query_id, q_supertype, created, name, corpus_name)'
+                    'VALUES (%s, %s, %s, %s, %s, %s)',
+                    full_data)
+            conn.commit()
 
         print(f'\n{max(cursor.rowcount, 0)} entries has been inserted.')

--- a/lib/plugins/mysql_query_persistence/__init__.py
+++ b/lib/plugins/mysql_query_persistence/__init__.py
@@ -65,8 +65,7 @@ PARTITION BY RANGE (UNIX_TIMESTAMP(created)) (
 
 import re
 import json
-from mysql.connector.connection import MySQLConnection
-from mysql.connector.cursor import MySQLCursor
+from aiomysql import Connection, Cursor
 from typing import Union
 
 import plugins
@@ -113,7 +112,7 @@ class MySqlQueryPersistence(AbstractQueryPersistence):
             self,
             settings,
             db,
-            sql_backend: Union[IntegrationDatabase[MySQLConnection, MySQLCursor], MySQLOps],
+            sql_backend: Union[IntegrationDatabase[Connection, Cursor], MySQLOps],
             auth):
         plugin_conf = settings.get('plugins', 'query_persistence')
         ttl_days = int(plugin_conf.get('ttl_days', MySqlQueryPersistence.DEFAULT_TTL_DAYS))
@@ -159,25 +158,25 @@ class MySqlQueryPersistence(AbstractQueryPersistence):
             return self.anonymous_user_ttl
         return self._ttl_days
 
-    def _find_used_corpora(self, query_id):
+    async def _find_used_corpora(self, query_id):
         """
         Because the operations are chained via 'prev_id' and the corpname
         information is not stored for all the steps, for any n-th step > 1
         we have to go backwards and find an actual corpname stored in the
         1st operation.
         """
-        data = self._load_query(query_id, save_access=False)
+        data = await self._load_query(query_id, save_access=False)
         while data is not None and 'corpname' not in data:
-            data = self._load_query(data.get('prev_id', ''), save_access=False)
+            data = await self._load_query(data.get('prev_id', ''), save_access=False)
         return data.get('corpora', []) if data is not None else []
 
-    def open(self, data_id):
-        ans = self._load_query(data_id, save_access=True)
+    async def open(self, data_id):
+        ans = await self._load_query(data_id, save_access=True)
         if ans is not None and 'corpora' not in ans:
-            ans['corpora'] = self._find_used_corpora(ans.get('prev_id'))
+            ans['corpora'] = await self._find_used_corpora(ans.get('prev_id'))
         return ans
 
-    def _load_query(self, data_id: str, save_access: bool):
+    async def _load_query(self, data_id: str, save_access: bool):
         """
         Loads operation data according to the passed data_id argument.
         The data are assumed to be public (as are URL parameters of a query).
@@ -191,26 +190,26 @@ class MySqlQueryPersistence(AbstractQueryPersistence):
         try:
             data = self.db.get(mk_key(data_id))
             if data is None:
-                cursor = self._archive.cursor()
-                cursor.execute(
-                    'SELECT data, created, num_access FROM kontext_conc_persistence WHERE id = %s LIMIT 1', (data_id,))
-                tmp = cursor.fetchone()
-                if tmp:
-                    data = json.loads(tmp['data'])
-                    if save_access:
-                        cursor.execute(
-                            'UPDATE kontext_conc_persistence '
-                            'SET last_access = %s, num_access = num_access + 1 '
-                            'WHERE id = %s AND created = %s',
-                            (get_iso_datetime(), data_id, tmp['created'].isoformat())
-                        )
-                        self._archive.commit()
+                async with self._archive.cursor() as cursor:
+                    await cursor.execute(
+                        'SELECT data, created, num_access FROM kontext_conc_persistence WHERE id = %s LIMIT 1', (data_id,))
+                    tmp = await cursor.fetchone()
+                    if tmp:
+                        data = json.loads(tmp['data'])
+                        if save_access:
+                            await cursor.execute(
+                                'UPDATE kontext_conc_persistence '
+                                'SET last_access = %s, num_access = num_access + 1 '
+                                'WHERE id = %s AND created = %s',
+                                (get_iso_datetime(), data_id, tmp['created'].isoformat())
+                            )
+                            await self._archive.commit()
             return data
         except Exception as ex:
             logging.getLogger(__name__).error(f'Failed to restore archived concordance {data_id}: {ex}')
             raise ex
 
-    def store(self, user_id, curr_data, prev_data=None):
+    async def store(self, user_id, curr_data, prev_data=None):
         """
         Stores current operation (defined in curr_data) into the database. If also prev_date argument is
         provided then a comparison is performed and based on the result, new record is created and new
@@ -246,49 +245,49 @@ class MySqlQueryPersistence(AbstractQueryPersistence):
 
         return latest_id
 
-    def archive(self, user_id, conc_id, revoke=False):
-        cursor = self._archive.cursor()
-        cursor.execute(
-            'SELECT id, data, created, num_access, last_access FROM kontext_conc_persistence WHERE id = %s LIMIT 1',
-            (conc_id,)
-        )
-        row = cursor.fetchone()
-        archived_rec = json.loads(row['data']) if row is not None else None
+    async def archive(self, user_id, conc_id, revoke=False):
+        async with self._archive.cursor() as cursor:
+            await cursor.execute(
+                'SELECT id, data, created, num_access, last_access FROM kontext_conc_persistence WHERE id = %s LIMIT 1',
+                (conc_id,)
+            )
+            row = await cursor.fetchone()
+            archived_rec = json.loads(row['data']) if row is not None else None
 
-        if revoke:
-            if archived_rec:
-                cursor.execute('DELETE FROM kontext_conc_persistence WHERE id = %s', (conc_id,))
-                ans = 1
+            if revoke:
+                if archived_rec:
+                    await cursor.execute('DELETE FROM kontext_conc_persistence WHERE id = %s', (conc_id,))
+                    ans = 1
+                else:
+                    raise NotFoundException(
+                        'Archive revoke error - concordance {0} not archived'.format(conc_id))
             else:
-                raise NotFoundException(
-                    'Archive revoke error - concordance {0} not archived'.format(conc_id))
-        else:
-            cursor = self._archive.cursor()
-            data = self.db.get(mk_key(conc_id))
-            if data is None and archived_rec is None:
-                raise NotFoundException(
-                    'Archive store error - concordance {0} not found'.format(conc_id))
-            elif archived_rec:
-                ans = 0
-            else:
-                stored_user_id = data.get('user_id', None)
-                if user_id != stored_user_id:
-                    raise ForbiddenException(
-                        'Cannot change status of a concordance belonging to another user')
-                cursor.execute(
-                    'INSERT IGNORE INTO kontext_conc_persistence (id, data, created, num_access) '
-                    'VALUES (%s, %s, %s, %s)',
-                    (conc_id, json.dumps(data), get_iso_datetime(), 0))
-                archived_rec = data
-                ans = 1
-        self._archive.commit()
+                data = self.db.get(mk_key(conc_id))
+                if data is None and archived_rec is None:
+                    raise NotFoundException(
+                        'Archive store error - concordance {0} not found'.format(conc_id))
+                elif archived_rec:
+                    ans = 0
+                else:
+                    stored_user_id = data.get('user_id', None)
+                    if user_id != stored_user_id:
+                        raise ForbiddenException(
+                            'Cannot change status of a concordance belonging to another user')
+                    await cursor.execute(
+                        'INSERT IGNORE INTO kontext_conc_persistence (id, data, created, num_access) '
+                        'VALUES (%s, %s, %s, %s)',
+                        (conc_id, json.dumps(data), get_iso_datetime(), 0))
+                    archived_rec = data
+                    ans = 1
+        await self._archive.commit()
         return ans, archived_rec
 
-    def is_archived(self, conc_id):
-        return is_archived(self._archive.cursor(), conc_id)
+    async def is_archived(self, conc_id):
+        async with self._archive.cursor() as cursor:
+            return await is_archived(cursor, conc_id)
 
-    def will_be_archived(self, plugin_ctx, conc_id: str):
-        return not self.is_archived(conc_id)\
+    async def will_be_archived(self, plugin_ctx, conc_id: str):
+        return not (await self.is_archived(conc_id))\
             and self._settings.get('plugins', 'query_persistence').get('implicit_archiving', None) in ('true', '1', 1)\
             and not self._auth.is_anonymous(plugin_ctx.user_id)
 
@@ -304,7 +303,7 @@ class MySqlQueryPersistence(AbstractQueryPersistence):
 
 
 @inject(plugins.runtime.DB, plugins.runtime.INTEGRATION_DB, plugins.runtime.AUTH)
-def create_instance(settings, db: IntegrationDatabase[MySQLConnection, MySQLCursor], integration_db, auth):
+def create_instance(settings, db, integration_db: IntegrationDatabase[Connection, Cursor], auth):
     """
     Creates a plugin instance.
     """
@@ -313,6 +312,7 @@ def create_instance(settings, db: IntegrationDatabase[MySQLConnection, MySQLCurs
         logging.getLogger(__name__).info(f'mysql_query_persistence uses integration_db[{integration_db.info}]')
         return MySqlQueryPersistence(settings, db, integration_db, auth)
     else:
+        raise NotImplementedError('Asynchronous MySQLOps not implemented yet')
         logging.getLogger(__name__).info(
             'mysql_query_persistence uses custom database configuration {}@{}'.format(
                 plugin_conf['mysql_user'], plugin_conf['mysql_host']))

--- a/lib/plugins/mysql_query_persistence/archive.py
+++ b/lib/plugins/mysql_query_persistence/archive.py
@@ -25,7 +25,7 @@ import logging
 
 import json
 import redis
-from mysql.connector.cursor import MySQLCursor
+from aiomysql import Cursor
 from plugins.common.mysql import MySQLOps
 from plugin_types.general_storage import KeyValueStorage
 
@@ -41,12 +41,12 @@ def get_iso_datetime():
     return datetime.datetime.now().isoformat()
 
 
-def is_archived(cursor: MySQLCursor, conc_id):
-    cursor.execute(
+async def is_archived(cursor: Cursor, conc_id):
+    await cursor.execute(
         'SELECT id FROM kontext_conc_persistence WHERE id = %s LIMIT 1',
         (conc_id,)
     )
-    return cursor.fetchone() is not None
+    return (await cursor.fetchone()) is not None
 
 
 class Archiver(object):

--- a/lib/plugins/mysql_query_persistence/scripts/import.py
+++ b/lib/plugins/mysql_query_persistence/scripts/import.py
@@ -43,18 +43,20 @@ def import_sqlite_db(db_path, chunk_size):
         while True:
             data = cursor.fetchmany(chunk_size)
             if len(data):
-                mysql_db.executemany(
-                    'INSERT IGNORE INTO kontext_conc_persistence (id, data, created, num_access, last_access) '
-                    'VALUES (%s, %s, %s, %s, %s)',
-                    [(
-                        d[0],
-                        d[1],
-                        datetime.datetime.fromtimestamp(d[2]).isoformat(),
-                        d[3],
-                        datetime.datetime.fromtimestamp(d[4]).isoformat() if d[4] else None
-                    ) for d in data]
-                )
-                mysql_db.commit()
+                with mysql_db.connection_sync() as conn:
+                    with conn.cursor() as cursor:
+                        cursor.executemany(
+                            'INSERT IGNORE INTO kontext_conc_persistence (id, data, created, num_access, last_access) '
+                            'VALUES (%s, %s, %s, %s, %s)',
+                            [(
+                                d[0],
+                                d[1],
+                                datetime.datetime.fromtimestamp(d[2]).isoformat(),
+                                d[3],
+                                datetime.datetime.fromtimestamp(d[4]).isoformat() if d[4] else None
+                            ) for d in data]
+                        )
+                    conn.commit()
             else:
                 break
 

--- a/lib/plugins/mysql_subc_restore/__init__.py
+++ b/lib/plugins/mysql_subc_restore/__init__.py
@@ -20,13 +20,12 @@ import urllib.request
 import urllib.parse
 import urllib.error
 import logging
-from aiomysql import Connection, Cursor
 
 import werkzeug.urls
+from plugins.mysql_integration_db import MySqlIntegrationDb
 import plugins
 from plugin_types.corparch import AbstractCorporaArchive
 from plugin_types.subc_restore import AbstractSubcRestore, SubcRestoreRow
-from plugin_types.integration_db import IntegrationDatabase
 from plugins.errors import PluginCompatibilityException
 from plugins import inject
 
@@ -42,7 +41,7 @@ class MySQLSubcRestore(AbstractSubcRestore):
             self,
             plugin_conf: Dict[str, Any],
             corparch: AbstractCorporaArchive,
-            db: IntegrationDatabase[Connection, Cursor]):
+            db: MySqlIntegrationDb):
         self._conf = plugin_conf
         self._corparch = corparch
         self._db = db
@@ -179,10 +178,11 @@ class MySQLSubcRestore(AbstractSubcRestore):
 
 
 @inject(plugins.runtime.CORPARCH, plugins.runtime.INTEGRATION_DB)
-def create_instance(conf, corparch, integ_db: IntegrationDatabase[Connection, Cursor]):
+def create_instance(conf, corparch, integ_db: MySqlIntegrationDb):
     plugin_conf = conf.get('plugins', 'subc_restore')
     if integ_db.is_active:
         logging.getLogger(__name__).info(f'mysql_subc_restore uses integration_db[{integ_db.info}]')
         return MySQLSubcRestore(plugin_conf, corparch, integ_db)
     else:
-        raise PluginCompatibilityException('mysql_subc_restore works only with integration_db enabled')
+        raise PluginCompatibilityException(
+            'mysql_subc_restore works only with integration_db enabled')

--- a/lib/plugins/mysql_subcmixer/__init__.py
+++ b/lib/plugins/mysql_subcmixer/__init__.py
@@ -17,6 +17,8 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 from typing import Any, Dict, List, Tuple, Union
+
+from plugins.mysql_integration_db import MySqlIntegrationDb
 try:
     from typing import TypedDict
 except ImportError:
@@ -25,13 +27,11 @@ from collections import defaultdict
 import json
 import struct
 
-from aiomysql import Connection, Cursor
 from sanic.blueprints import Blueprint
 
 import plugins
 from plugins import inject
 from plugin_types.corparch import AbstractCorporaArchive
-from plugin_types.integration_db import IntegrationDatabase
 from plugin_types.subcmixer import AbstractSubcMixer, ExpressionItem
 from plugin_types.subcmixer.error import SubcMixerException, ResultNotFoundException
 from action.plugin.ctx import PluginCtx
@@ -48,7 +48,7 @@ To be able to use the plug-in, the following requirements must be met:
 
 - enabled mysql_integration_db (i.e. the mysql_subcmixer does not provide its individual db connection)
 - enabled mysql_live_attributes
-- also, a corpus we want to used the plug-in with must have bib_id_struct, bib_id_attr configured 
+- also, a corpus we want to used the plug-in with must have bib_id_struct, bib_id_attr configured
 """
 
 bp = Blueprint('mysql_subcmixer')
@@ -127,7 +127,7 @@ class SubcMixer(AbstractSubcMixer[ProcessResponse]):
     CORPUS_MAX_SIZE = 500000000  # TODO
 
     def __init__(
-            self, corparch: AbstractCorporaArchive, integration_db: IntegrationDatabase[Connection, Cursor]):
+            self, corparch: AbstractCorporaArchive, integration_db: MySqlIntegrationDb):
         self._corparch = corparch
         self._db = integration_db
 
@@ -210,5 +210,5 @@ class SubcMixer(AbstractSubcMixer[ProcessResponse]):
 
 @inject(plugins.runtime.CORPARCH, plugins.runtime.INTEGRATION_DB)
 def create_instance(
-        settings, corparch: AbstractCorporaArchive, integration_db: IntegrationDatabase[Connection, Cursor]):
+        settings, corparch: AbstractCorporaArchive, integration_db: MySqlIntegrationDb):
     return SubcMixer(corparch, integration_db)

--- a/lib/plugins/mysql_subcmixer/category_tree.py
+++ b/lib/plugins/mysql_subcmixer/category_tree.py
@@ -22,8 +22,7 @@ from typing import Iterator, List, NamedTuple, Optional, Union
 import copy
 
 import numpy as np
-from mysql.connector.connection import MySQLConnection
-from mysql.connector.cursor import MySQLCursor
+from aiomysql import Connection, Cursor
 
 from plugin_types.integration_db import IntegrationDatabase
 
@@ -129,7 +128,7 @@ class CategoryTree(object):
 
     """
 
-    def __init__(self, category_list: List[TaskArgs], db: IntegrationDatabase[MySQLConnection, MySQLCursor], corpus_id: str, aligned_corpora: List[str], corpus_max_size: int):
+    def __init__(self, category_list: List[TaskArgs], db: IntegrationDatabase[Connection, Cursor], corpus_id: str, aligned_corpora: List[str], corpus_max_size: int):
         self.category_list = category_list
         self.num_categories = len(category_list)
         self.corpus_max_size = corpus_max_size
@@ -259,9 +258,9 @@ class CategoryTree(object):
             {' '.join(aligned_join)}
         '''
 
-        with self._db.cursor() as cursor:
-            cursor.execute(sql, (self.corpus_id, *self.aligned_corpora))
-            row = cursor.fetchone()
+        async with self._db.cursor() as cursor:
+            await cursor.execute(sql, (self.corpus_id, *self.aligned_corpora))
+            row = await cursor.fetchone()
 
         if row is None or not row['poscount']:
             raise CategoryTreeException('Failed to initialize bounds')
@@ -317,8 +316,8 @@ class CategoryTree(object):
         )
         params += tuple(self.aligned_corpora)
 
-        with self._db.cursor() as cursor:
-            cursor.execute(sql, params)
-            row = cursor.fetchone()
+        async with self._db.cursor() as cursor:
+            await cursor.execute(sql, params)
+            row = await cursor.fetchone()
 
         return 0 if row['poscount'] is None else int(row['poscount'])

--- a/lib/plugins/mysql_subcmixer/category_tree.py
+++ b/lib/plugins/mysql_subcmixer/category_tree.py
@@ -22,9 +22,7 @@ from typing import Iterator, List, NamedTuple, Optional, Union
 import copy
 
 import numpy as np
-from aiomysql import Connection, Cursor
-
-from plugin_types.integration_db import IntegrationDatabase
+from lib.plugins.mysql_integration_db import MySqlIntegrationDb
 
 
 class CategoryExpression(object):
@@ -128,7 +126,7 @@ class CategoryTree(object):
 
     """
 
-    def __init__(self, category_list: List[TaskArgs], db: IntegrationDatabase[Connection, Cursor], corpus_id: str, aligned_corpora: List[str], corpus_max_size: int):
+    def __init__(self, category_list: List[TaskArgs], db: MySqlIntegrationDb, corpus_id: str, aligned_corpora: List[str], corpus_max_size: int):
         self.category_list = category_list
         self.num_categories = len(category_list)
         self.corpus_max_size = corpus_max_size

--- a/lib/plugins/mysql_subcmixer/metadata_model.py
+++ b/lib/plugins/mysql_subcmixer/metadata_model.py
@@ -21,9 +21,8 @@ from typing import Optional, Set, Tuple, List, Dict
 
 import numpy as np
 import pulp
-from aiomysql import Connection, Cursor
+from plugins.mysql_integration_db import MySqlIntegrationDb
 
-from plugin_types.integration_db import IntegrationDatabase
 from .category_tree import CategoryTree, CategoryTreeNode
 
 
@@ -57,7 +56,7 @@ class MetadataModel:
     """
 
     @classmethod
-    async def create(cls, db: IntegrationDatabase[Connection, Cursor], category_tree: CategoryTree, id_attr: str):
+    async def create(cls, db: MySqlIntegrationDb, category_tree: CategoryTree, id_attr: str):
         self = await MetadataModel.create(db, category_tree, id_attr)
         self.text_sizes, self._id_map = await self._get_text_sizes()
         # text_sizes and _id_map both contain all the documents from the corpus
@@ -73,7 +72,7 @@ class MetadataModel:
         return self
 
     def __init__(
-            self, db: IntegrationDatabase[Connection, Cursor], category_tree: CategoryTree, id_attr: str):
+            self, db: MySqlIntegrationDb, category_tree: CategoryTree, id_attr: str):
         self._db = db
         self.category_tree = category_tree
         self._id_struct, self._id_attr = id_attr.split('.')
@@ -143,7 +142,7 @@ class MetadataModel:
                         SELECT t_map.value_tuple_id
                         FROM corpus_structattr_value AS t_value
                         JOIN corpus_structattr_value_mapping AS t_map ON t_map.value_id = t_value.id
-                        WHERE t_value.corpus_name = %s AND t_value.structure_name = %s AND t_value.structattr_name = %s 
+                        WHERE t_value.corpus_name = %s AND t_value.structure_name = %s AND t_value.structattr_name = %s
                             AND t_value.value {mc.mysql_op} %s
                         '''
                 for subl in node.metadata_condition

--- a/lib/plugins/mysql_token_auth/__init__.py
+++ b/lib/plugins/mysql_token_auth/__init__.py
@@ -26,8 +26,7 @@ from datetime import datetime
 import hashlib
 from typing import List, Optional
 
-from mysql.connector.connection import MySQLConnection
-from mysql.connector.cursor import MySQLCursor
+from aiomysql import Connection, Cursor
 from action.plugin.ctx import PluginCtx
 
 import plugins
@@ -39,7 +38,7 @@ class TokenAuth(AbstractRemoteAuth):
 
     def __init__(
         self,
-        db: IntegrationDatabase[MySQLConnection, MySQLCursor],
+        db: IntegrationDatabase[Connection, Cursor],
         anonymous_id: int,
         api_key_cookie_name: Optional[str],
         api_key_http_header: Optional[str],
@@ -105,8 +104,8 @@ class TokenAuth(AbstractRemoteAuth):
             plugin_ctx.session['user'] = self.anonymous_user(plugin_ctx)
 
     async def _find_user(self, api_key: str) -> Optional[UserInfo]:
-        with self._db.cursor() as cursor:
-            cursor.execute('''
+        async with self._db.cursor() as cursor:
+            await cursor.execute('''
                 SELECT t_token.user_id AS id, t_user.username, t_user.email,
                    CONCAT_WS(" ", t_user.firstname, t_user.lastname) AS fullname
                 FROM kontext_api_token AS t_token
@@ -115,29 +114,29 @@ class TokenAuth(AbstractRemoteAuth):
                       active = 1 AND
                       valid_until >= %s
             ''', (api_key, datetime.now()))
-            data = cursor.fetchone()
-            if data is None:
-                return None
-            return UserInfo(
-                id=data['id'],
-                user=data['username'],
-                fullname=data['fullname'],
-                email=data['email'],
-                api_key=api_key)
+            data = await cursor.fetchone()
+        if data is None:
+            return None
+        return UserInfo(
+            id=data['id'],
+            user=data['username'],
+            fullname=data['fullname'],
+            email=data['email'],
+            api_key=api_key)
 
     async def _get_permitted_corpora(self, user_dict: UserInfo) -> List[str]:
-        with self._db.cursor() as cursor:
-            cursor.execute('''
+        async with self._db.cursor() as cursor:
+            await cursor.execute('''
                 SELECT GROUP_CONCAT(corpus_name SEPARATOR ',') AS corpora
                 FROM kontext_api_token_corpus_access
                 WHERE token_value = %s AND user_id = %s
             ''', (user_dict['api_key'], user_dict['id']))
-            data = cursor.fetchone()
-            return [] if data['corpora'] is None else list(data['corpora'].split(','))
+            data = await cursor.fetchone()
+        return [] if data['corpora'] is None else list(data['corpora'].split(','))
 
 
 @plugins.inject(plugins.runtime.INTEGRATION_DB)
-def create_instance(conf, integration_db: IntegrationDatabase[MySQLConnection, MySQLCursor]):
+def create_instance(conf, integration_db: IntegrationDatabase[Connection, Cursor]):
     """
     This function must be always implemented. KonText uses it to create an instance of your
     authentication object. The settings module is passed as a parameter.

--- a/lib/plugins/mysql_token_auth/__init__.py
+++ b/lib/plugins/mysql_token_auth/__init__.py
@@ -75,7 +75,7 @@ class TokenAuth(AbstractRemoteAuth):
         else:
             return await self._get_permitted_corpora(user_dict)
 
-    def get_user_info(self, plugin_ctx: PluginCtx) -> UserInfo:
+    async def get_user_info(self, plugin_ctx: PluginCtx) -> UserInfo:
         return plugin_ctx.session['user']
 
     def _get_api_key(self, plugin_ctx: PluginCtx) -> Optional[str]:

--- a/lib/plugins/mysql_token_auth/__init__.py
+++ b/lib/plugins/mysql_token_auth/__init__.py
@@ -26,19 +26,18 @@ from datetime import datetime
 import hashlib
 from typing import List, Optional
 
-from aiomysql import Connection, Cursor
 from action.plugin.ctx import PluginCtx
+from plugins.mysql_integration_db import MySqlIntegrationDb
 
 import plugins
 from plugin_types.auth import AbstractRemoteAuth, CorpusAccess, UserInfo
-from plugin_types.integration_db import IntegrationDatabase
 
 
 class TokenAuth(AbstractRemoteAuth):
 
     def __init__(
         self,
-        db: IntegrationDatabase[Connection, Cursor],
+        db: MySqlIntegrationDb,
         anonymous_id: int,
         api_key_cookie_name: Optional[str],
         api_key_http_header: Optional[str],
@@ -136,7 +135,7 @@ class TokenAuth(AbstractRemoteAuth):
 
 
 @plugins.inject(plugins.runtime.INTEGRATION_DB)
-def create_instance(conf, integration_db: IntegrationDatabase[Connection, Cursor]):
+def create_instance(conf, integration_db: MySqlIntegrationDb):
     """
     This function must be always implemented. KonText uses it to create an instance of your
     authentication object. The settings module is passed as a parameter.

--- a/lib/plugins/mysql_user_items/__init__.py
+++ b/lib/plugins/mysql_user_items/__init__.py
@@ -16,6 +16,8 @@ import json
 import logging
 from sanic.blueprints import Blueprint
 
+from plugins.mysql_integration_db import MySqlIntegrationDb
+
 from .backend import Backend
 
 from plugin_types.user_items import AbstractUserItems, UserItemException, FavoriteItem
@@ -142,7 +144,7 @@ class MySQLUserItems(AbstractUserItems):
 
 
 @inject(plugins.runtime.INTEGRATION_DB, plugins.runtime.AUTH)
-def create_instance(settings, integ_db, auth):
+def create_instance(settings, integ_db: MySqlIntegrationDb, auth):
     plugin_conf = settings.get('plugins', 'user_items')
     if integ_db.is_active and 'mysql_host' not in plugin_conf:
         logging.getLogger(__name__).info(f'mysql_user_items uses integration_db[{integ_db.info}]')

--- a/lib/plugins/mysql_user_items/__init__.py
+++ b/lib/plugins/mysql_user_items/__init__.py
@@ -148,6 +148,7 @@ def create_instance(settings, integ_db, auth):
         logging.getLogger(__name__).info(f'mysql_user_items uses integration_db[{integ_db.info}]')
         db_backend = Backend(integ_db)
     else:
+        raise NotImplementedError('Asynchronous MySQLOps not implemented yet')
         from plugins.common.mysql import MySQLOps, MySQLConf
         logging.getLogger(__name__).info(
             'mysql_user_items uses custom database configuration {}@{}'.format(

--- a/lib/plugins/mysql_user_items/backend.py
+++ b/lib/plugins/mysql_user_items/backend.py
@@ -22,10 +22,9 @@ A corparch database backend for MySQL/MariaDB.
 """
 from typing import Union
 
-from aiomysql import Connection, Cursor
+from plugins.mysql_integration_db import MySqlIntegrationDb
 
 from plugin_types.user_items import FavoriteItem
-from plugin_types.integration_db import IntegrationDatabase
 from plugins.common.mysql import MySQLOps
 
 
@@ -42,7 +41,7 @@ class Backend:
 
     def __init__(
             self,
-            db: Union[IntegrationDatabase[Connection, Cursor], MySQLOps],
+            db: Union[MySqlIntegrationDb, MySQLOps],
             user_table: str = DFLT_USER_TABLE,
             corp_table: str = DFLT_CORP_TABLE,
             group_acc_table: str = DFLT_GROUP_ACC_TABLE,

--- a/lib/plugins/mysql_user_items/backend.py
+++ b/lib/plugins/mysql_user_items/backend.py
@@ -22,7 +22,7 @@ A corparch database backend for MySQL/MariaDB.
 """
 from typing import Union
 
-import aiomysql
+from aiomysql import Connection, Cursor
 
 from plugin_types.user_items import FavoriteItem
 from plugin_types.integration_db import IntegrationDatabase
@@ -42,7 +42,7 @@ class Backend:
 
     def __init__(
             self,
-            db: Union[IntegrationDatabase[aiomysql.Connection, aiomysql.Cursor], MySQLOps],
+            db: Union[IntegrationDatabase[Connection, Cursor], MySQLOps],
             user_table: str = DFLT_USER_TABLE,
             corp_table: str = DFLT_CORP_TABLE,
             group_acc_table: str = DFLT_GROUP_ACC_TABLE,

--- a/lib/plugins/mysql_user_items/backend.py
+++ b/lib/plugins/mysql_user_items/backend.py
@@ -20,9 +20,9 @@
 A corparch database backend for MySQL/MariaDB.
 
 """
-from mysql.connector.connection import MySQLConnection
-from mysql.connector.cursor import MySQLCursor
 from typing import Union
+
+import aiomysql
 
 from plugin_types.user_items import FavoriteItem
 from plugin_types.integration_db import IntegrationDatabase
@@ -42,7 +42,7 @@ class Backend:
 
     def __init__(
             self,
-            db: Union[IntegrationDatabase[MySQLConnection, MySQLCursor], MySQLOps],
+            db: Union[IntegrationDatabase[aiomysql.Connection, aiomysql.Cursor], MySQLOps],
             user_table: str = DFLT_USER_TABLE,
             corp_table: str = DFLT_CORP_TABLE,
             group_acc_table: str = DFLT_GROUP_ACC_TABLE,
@@ -60,7 +60,7 @@ class Backend:
         self._group_acc_group_attr = group_acc_group_attr
 
     async def get_favitems(self, user_id: int):
-        with self._db.cursor() as cursor:
+        async with self._db.cursor() as cursor:
             await cursor.execute(
                 'SELECT fav.id as id, fav.name, fav.subcorpus_id, fav.subcorpus_orig_id, '
                 " GROUP_CONCAT(t.corpus_name SEPARATOR ',') as corpora, "
@@ -72,7 +72,7 @@ class Backend:
                 'GROUP BY id ', (user_id,))
 
             ans = []
-            for item in cursor:
+            async for item in cursor:
                 item['corpora'] = [{'name': corp, 'id': corp}
                                    for corp in item['corpora'].split(',')]
                 item['size'] = int(item['sizes'].split(',')[0])
@@ -81,30 +81,30 @@ class Backend:
         return ans
 
     async def count_favitems(self, user_id: int) -> int:
-        with self._db.cursor() as cursor:
-            cursor.execute(
+        async with self._db.cursor() as cursor:
+            await cursor.execute(
                 'SELECT COUNT(*) AS count '
                 'FROM kontext_user_fav_item '
                 'WHERE user_id = %s ', (user_id,))
-            return cursor.fetchone()
+            return await cursor.fetchone()
 
     async def insert_favitem(self, user_id: int, item: FavoriteItem):
-        with self._db.cursor() as cursor:
-            cursor.execute(
+        async with self._db.cursor() as cursor:
+            await cursor.execute(
                 'INSERT INTO kontext_user_fav_item (name, subcorpus_id, subcorpus_orig_id, user_id) '
                 'VALUES (%s, %s, %s, %s) ', (item.name, item.subcorpus_id, item.subcorpus_orig_id, user_id))
 
             favitem_id: int = cursor.lastrowid
-            cursor.executemany(
+            await cursor.executemany(
                 'INSERT INTO kontext_corpus_user_fav_item (user_fav_corpus_id, corpus_name) '
                 'VALUES (%s, %s) ', [(favitem_id, corp['id']) for corp in item.corpora])
 
-        self._db.commit()
+        await self._db.commit()
         item.ident = str(favitem_id)  # need to update new id
 
     async def delete_favitem(self, item_id: int):
-        with self._db.cursor() as cursor:
-            cursor.execute(
+        async with self._db.cursor() as cursor:
+            await cursor.execute(
                 'DELETE FROM kontext_corpus_user_fav_item WHERE user_fav_corpus_id = %s', (item_id,))
-            cursor.execute('DELETE FROM kontext_user_fav_item WHERE id = %s', (item_id,))
-        self._db.commit()
+            await cursor.execute('DELETE FROM kontext_user_fav_item WHERE id = %s', (item_id,))
+        await self._db.commit()

--- a/lib/plugins/sqlite_live_attributes/__init__.py
+++ b/lib/plugins/sqlite_live_attributes/__init__.py
@@ -52,35 +52,35 @@ bp = Blueprint('sqlite_live_attributes')
 
 @bp.route('/filter_attributes', methods=['POST'])
 @http_action(return_type='json', action_model=CorpusActionModel)
-def filter_attributes(self, request):
+async def filter_attributes(self, request):
     attrs = json.loads(request.form.get('attrs', '{}'))
     aligned = json.loads(request.form.get('aligned', '[]'))
     with plugins.runtime.LIVE_ATTRIBUTES as lattr:
-        return lattr.get_attr_values(self._plugin_ctx, corpus=self.corp, attr_map=attrs,
+        return await lattr.get_attr_values(self._plugin_ctx, corpus=self.corp, attr_map=attrs,
                                      aligned_corpora=aligned)
 
 
 @bp.route('/attr_val_autocomplete', methods=['POST'])
 @http_action(return_type='json', action_model=CorpusActionModel)
-def attr_val_autocomplete(self, request):
+async def attr_val_autocomplete(self, request):
     attrs = json.loads(request.form.get('attrs', '{}'))
     attrs[request.form.get('patternAttr')] = '%{}%'.format(request.form.get('pattern'))
     aligned = json.loads(request.form.get('aligned', '[]'))
     with plugins.runtime.LIVE_ATTRIBUTES as lattr:
-        return lattr.get_attr_values(self._plugin_ctx, corpus=self.corp, attr_map=attrs,
+        return await lattr.get_attr_values(self._plugin_ctx, corpus=self.corp, attr_map=attrs,
                                      aligned_corpora=aligned,
                                      autocomplete_attr=request.form.get('patternAttr'))
 
 
 @bp.route('/fill_attrs', methods=['POST'])
 @http_action(return_type='json', action_model=CorpusActionModel)
-def fill_attrs(self, request):
+async def fill_attrs(self, request):
     search = request.json['search']
     values = request.json['values']
     fill = request.json['fill']
 
     with plugins.runtime.LIVE_ATTRIBUTES as lattr:
-        return lattr.fill_attrs(corpus_id=self.corp.corpname, search=search, values=values, fill=fill)
+        return await lattr.fill_attrs(corpus_id=self.corp.corpname, search=search, values=values, fill=fill)
 
 
 class LiveAttributes(CachedLiveAttributes):
@@ -196,7 +196,7 @@ class LiveAttributes(CachedLiveAttributes):
         id_attr = corpus_info.metadata.id_attr
         return [id_attr.split('.')[0]] if id_attr else []
 
-    def get_subc_size(self, plugin_ctx, corpora, attr_map):
+    async def get_subc_size(self, plugin_ctx, corpora, attr_map):
         db = self.db(plugin_ctx, corpora[0])
         join_sql = []
         where_sql = ['t1.corpus_id = ?']

--- a/lib/plugins/stable_query_persistence/__init__.py
+++ b/lib/plugins/stable_query_persistence/__init__.py
@@ -85,7 +85,7 @@ class StableQueryPersistence(AbstractQueryPersistence):
             data = self._load_query(data.get('prev_id', ''), save_access=False)
         return data.get('corpora', []) if data is not None else []
 
-    def open(self, data_id):
+    async def open(self, data_id):
         ans = self._load_query(data_id, save_access=True)
         if ans is not None and 'corpora' not in ans:
             ans['corpora'] = self.find_used_corpora(ans.get('prev_id'))
@@ -126,7 +126,7 @@ class StableQueryPersistence(AbstractQueryPersistence):
                 return arch_db
         return None
 
-    def store(self, user_id, curr_data, prev_data=None):
+    async def store(self, user_id, curr_data, prev_data=None):
         def records_differ(r1, r2):
             return (r1[QUERY_KEY] != r2[QUERY_KEY] or
                     r1.get('lines_groups') != r2.get('lines_groups'))
@@ -150,7 +150,7 @@ class StableQueryPersistence(AbstractQueryPersistence):
     def _latest_archive(self):
         return self._archives[0]
 
-    def archive(self, user_id, conc_id, revoke=False):
+    async def archive(self, user_id, conc_id, revoke=False):
         archive_db = self.find_key_db(conc_id)
         if archive_db:
             cursor = archive_db.cursor()
@@ -190,10 +190,10 @@ class StableQueryPersistence(AbstractQueryPersistence):
         self._latest_archive.commit()
         return ans, archived_rec
 
-    def is_archived(self, conc_id):
+    async def is_archived(self, conc_id):
         return self.find_key_db(conc_id) is not None
 
-    def will_be_archived(self, plugin_ctx, conc_id: str):
+    async def will_be_archived(self, plugin_ctx, conc_id: str):
         return not self.is_archived(conc_id)\
             and self._settings.get('plugins', 'query_persistence').get('implicit_archiving', None) in ('true', '1', 1)\
             and not self._auth.is_anonymous(plugin_ctx.user_id)

--- a/lib/plugins/static_appbar/__init__.py
+++ b/lib/plugins/static_appbar/__init__.py
@@ -111,8 +111,8 @@ class StaticApplicationBar(AbstractApplicationBar):
     def get_scripts(self, plugin_ctx):
         return tuple(self._js_urls)
 
-    def get_contents(self, plugin_ctx, return_url):
-        user_info = self._auth.get_user_info(plugin_ctx)
+    async def get_contents(self, plugin_ctx, return_url):
+        user_info = await self._auth.get_user_info(plugin_ctx)
         lang = plugin_ctx.user_lang.split('_')[0]
         html = self._html_files.get(lang)
         if not html:

--- a/lib/plugins/static_auth/__init__.py
+++ b/lib/plugins/static_auth/__init__.py
@@ -92,14 +92,14 @@ class StaticAuth(AbstractRemoteAuth):
             return False, False, ''
         return False, True, zone.corpora[corpus_id]
 
-    def permitted_corpora(self, user_dict: UserInfo) -> List[str]:
+    async def permitted_corpora(self, user_dict: UserInfo) -> List[str]:
         if self.is_anonymous(user_dict['id']):
             return []
         else:
             zone = self._find_user(user_dict['id'])
             return list(zone.corpora.keys())
 
-    def get_user_info(self, plugin_ctx):
+    async def get_user_info(self, plugin_ctx):
         return plugin_ctx.session['user']
 
     def _hash_key(self, k):

--- a/lib/plugins/syntax_viewer2/__init__.py
+++ b/lib/plugins/syntax_viewer2/__init__.py
@@ -33,7 +33,6 @@ def create_instance(conf, auth, integ_db):
     if integ_db.is_active and 'config_path' not in plugin_conf:
         logging.getLogger(__name__).info(
             f'syntax_viewer2 uses integration_db[{integ_db.info}]')
-        # TODO asynchronous config load...
         corpora_conf = dsv.load_plugin_conf_from_db(integ_db)
     else:
         logging.getLogger(__name__).info(

--- a/lib/plugins/syntax_viewer2/__init__.py
+++ b/lib/plugins/syntax_viewer2/__init__.py
@@ -23,7 +23,6 @@ An improved default_syntax viewer with rewritten tree rendering
 
 import logging
 import plugins
-import asyncio
 import plugins.default_syntax_viewer as dsv
 from .backend.manatee import ManateeBackend2
 
@@ -34,6 +33,7 @@ def create_instance(conf, auth, integ_db):
     if integ_db.is_active and 'config_path' not in plugin_conf:
         logging.getLogger(__name__).info(
             f'syntax_viewer2 uses integration_db[{integ_db.info}]')
+        # TODO asynchronous config load...
         corpora_conf = dsv.load_plugin_conf_from_db(integ_db)
     else:
         logging.getLogger(__name__).info(

--- a/lib/plugins/syntax_viewer2/__init__.py
+++ b/lib/plugins/syntax_viewer2/__init__.py
@@ -22,13 +22,14 @@ An improved default_syntax viewer with rewritten tree rendering
 """
 
 import logging
+from plugin_types.integration_db import IntegrationDatabase
 import plugins
 import plugins.default_syntax_viewer as dsv
 from .backend.manatee import ManateeBackend2
 
 
 @plugins.inject(plugins.runtime.AUTH, plugins.runtime.INTEGRATION_DB)
-def create_instance(conf, auth, integ_db):
+def create_instance(conf, auth, integ_db: IntegrationDatabase):
     plugin_conf = conf.get('plugins', 'syntax_viewer')
     if integ_db.is_active and 'config_path' not in plugin_conf:
         logging.getLogger(__name__).info(

--- a/lib/plugins/ucnk_appbar3/__init__.py
+++ b/lib/plugins/ucnk_appbar3/__init__.py
@@ -68,7 +68,7 @@ class ApplicationBar3(AbstractApplicationBar):
         toolbar_obj = plugin_ctx.get_shared('toolbar')
         return self._process_scripts(toolbar_obj.get('scripts', {}))
 
-    def get_contents(self, plugin_ctx, return_url):
+    async def get_contents(self, plugin_ctx, return_url):
         toolbar_obj = plugin_ctx.get_shared('toolbar')
         if toolbar_obj:
             return toolbar_obj.get('html')

--- a/lib/plugins/ucnk_corparch3/__init__.py
+++ b/lib/plugins/ucnk_corparch3/__init__.py
@@ -38,6 +38,7 @@ import logging
 from collections import defaultdict
 import os
 from sanic import Blueprint
+from plugin_types.integration_db import IntegrationDatabase
 
 
 import plugins
@@ -87,7 +88,7 @@ def get_favorite_corpora(amodel, req, resp):
 
 @bp.route('/ask_corpus_access', methods=['POST'])
 @http_action(access_level=1, return_type='json', action_model=UserActionModel)
-def ask_corpus_access(amodel, req, resp):
+async def ask_corpus_access(amodel, req, resp):
     ans = {}
     with plugins.runtime.CORPARCH as ca:
         if amodel.plugin_ctx.user_is_anonymous:
@@ -134,9 +135,8 @@ class UcnkCorpArch3(MySQLCorparch):
                                                        offset=offset, limit=limit if limit > -1 else 1000000000,
                                                        favourites=favourites)
 
-    @as_async
-    def export(self, plugin_ctx):
-        ans = super(UcnkCorpArch3, self).export(plugin_ctx)
+    async def export(self, plugin_ctx):
+        ans = await super(UcnkCorpArch3, self).export(plugin_ctx)
         ans['initial_keywords'] = plugin_ctx.session.get(
             self.SESSION_KEYWORDS_KEY, [self.default_label])
         return ans
@@ -217,7 +217,7 @@ class UcnkCorpArch3(MySQLCorparch):
 
 
 @inject(plugins.runtime.USER_ITEMS, plugins.runtime.AUTH, plugins.runtime.INTEGRATION_DB)
-def create_instance(conf, user_items, auth, cnc_db):
+def create_instance(conf, user_items, auth, cnc_db: IntegrationDatabase):
     db_backend = Backend(
         cnc_db, user_table='user', corp_table='corpora', corp_id_attr='id',
         group_acc_table='relation', group_acc_corp_attr='corpora', group_acc_group_attr='corplist',

--- a/lib/plugins/ucnk_corparch3/__init__.py
+++ b/lib/plugins/ucnk_corparch3/__init__.py
@@ -92,7 +92,7 @@ def ask_corpus_access(amodel, req, resp):
     with plugins.runtime.CORPARCH as ca:
         if amodel.plugin_ctx.user_is_anonymous:
             raise ForbiddenException('Anonymous user cannot send the request')
-        status = ca.send_request_email(
+        status = await ca.send_request_email(
             corpus_id=req.form.get('corpusId'),
             plugin_ctx=amodel.plugin_ctx,
             custom_message=req.form.get('customMessage'))
@@ -156,14 +156,14 @@ class UcnkCorpArch3(MySQLCorparch):
                                                           (self._tag_prefix, s) for s in query_keywords))
         return await super(UcnkCorpArch3, self).search(plugin_ctx, query, offset, limit, filter_dict)
 
-    def send_request_email(self, corpus_id, plugin_ctx, custom_message):
+    async def send_request_email(self, corpus_id, plugin_ctx, custom_message):
         """
         returns:
         True if at least one recipient has been reached else False
         """
         errors = []
 
-        user_info = self._auth.get_user_info(plugin_ctx)
+        user_info = await self._auth.get_user_info(plugin_ctx)
         user_email = user_info['email']
         username = user_info['username']
 

--- a/lib/plugins/ucnk_remote_auth5/__init__.py
+++ b/lib/plugins/ucnk_remote_auth5/__init__.py
@@ -194,19 +194,19 @@ class CentralAuth(AbstractRemoteAuth):
         _, access, variant = self._db.corpus_access(user_dict['id'], corpus_name)
         return CorpusAccess(False, access, variant)
 
-    def permitted_corpora(self, user_dict):
+    async def permitted_corpora(self, user_dict):
         """
         Fetches list of corpora available to the current user
 
         arguments:
         user_dict -- a user credentials dictionary
         """
-        corpora = self._db.get_permitted_corpora(str(user_dict['id']))
+        corpora = await self._db.get_permitted_corpora(str(user_dict['id']))
         if IMPLICIT_CORPUS not in corpora:
             corpora.append(IMPLICIT_CORPUS)
         return corpora
 
-    def get_user_info(self, plugin_ctx):
+    async def get_user_info(self, plugin_ctx):
         ans = {}
         ans.update(plugin_ctx.user_dict)
         ans['username'] = ans['user']

--- a/lib/plugins/ucnk_remote_auth5/__init__.py
+++ b/lib/plugins/ucnk_remote_auth5/__init__.py
@@ -33,6 +33,7 @@ import http.client
 import json
 import ssl
 import logging
+from plugin_types.integration_db import IntegrationDatabase
 
 import plugins
 from plugin_types.auth import AbstractRemoteAuth, CorpusAccess, UserInfo
@@ -227,7 +228,7 @@ class CentralAuth(AbstractRemoteAuth):
 
 
 @inject(plugins.runtime.SESSIONS, plugins.runtime.INTEGRATION_DB)
-def create_instance(conf, sessions, cnc_db):
+def create_instance(conf, sessions, cnc_db: IntegrationDatabase):
     logging.getLogger(__name__).info(f'ucnk_remote_auth5 uses integration_db[{cnc_db.info}]')
     backend = Backend(
         cnc_db, user_table='user', corp_table='corpora', corp_id_attr='id',

--- a/lib/views/concordance.py
+++ b/lib/views/concordance.py
@@ -839,7 +839,7 @@ async def ajax_remove_selected_lines(amodel: ConcActionModel, req: KRequest, res
 @http_action(return_type='json', action_model=ConcActionModel)
 async def ajax_send_group_selection_link_to_mail(amodel: ConcActionModel, req: KRequest, resp: KResponse):
     with plugins.runtime.AUTH as auth:
-        user_info = auth.get_user_info(amodel.plugin_ctx)
+        user_info = await auth.get_user_info(amodel.plugin_ctx)
         user_email = user_info['email']
         username = user_info['user']
         smtp_server = mailing.smtp_factory()
@@ -960,7 +960,7 @@ async def get_adhoc_subcorp_size(amodel: ConcActionModel, req: KRequest, resp: K
             ' '.join('<{0} {1} />'.format(k, v) for k, v in tt_query))
         amodel.args.q = [query]
         conc = await get_conc(corp=amodel.corp, user_id=amodel.session_get('user', 'id'), q=amodel.args.q,
-                        fromp=amodel.args.fromp, pagesize=amodel.args.pagesize, asnc=0)
+                              fromp=amodel.args.fromp, pagesize=amodel.args.pagesize, asnc=0)
         return dict(total=conc.fullsize() if conc else None)
 
 

--- a/lib/views/user.py
+++ b/lib/views/user.py
@@ -32,7 +32,7 @@ async def loginx(amodel, req, resp):
     So for compatibility reasons, let's keep this.
     """
     with plugins.runtime.AUTH as auth:
-        req.ctx.session['user'] = auth.validate_user(amodel.plugin_ctx, None, None)
+        req.ctx.session['user'] = await auth.validate_user(amodel.plugin_ctx, None, None)
     if req.args.get('return_url', None):
         amodel.redirect(req.args.get('return_url'))
     return {}
@@ -44,7 +44,7 @@ async def login(amodel, req, resp):
     amodel.disabled_menu_items = amodel.USER_ACTIONS_DISABLED_ITEMS
     with plugins.runtime.AUTH as auth:
         ans = {}
-        req.ctx.session['user'] = auth.validate_user(
+        req.ctx.session['user'] = await auth.validate_user(
             amodel.plugin_ctx, req.form.get('username'), req.form.get('password'))
         if not auth.is_anonymous(req.session['user'].get('id', None)):
             if req.args.get('return_url', None):
@@ -99,7 +99,7 @@ async def sign_up_form(amodel, req, resp):
     access_level=0, return_type='json', action_model=UserActionModel)
 async def sign_up(amodel, req, resp):
     with plugins.runtime.AUTH as auth:
-        errors = auth.sign_up_user(amodel.plugin_ctx, dict(
+        errors = await auth.sign_up_user(amodel.plugin_ctx, dict(
             username=req.form.get('username'),
             firstname=req.form.get('firstname'),
             lastname=req.form.get('lastname'),
@@ -118,7 +118,7 @@ async def sign_up(amodel, req, resp):
 @http_action(access_level=0, return_type='json', action_model=UserActionModel)
 async def test_username(amodel, req, resp):
     with plugins.runtime.AUTH as auth:
-        available, valid = auth.validate_new_username(
+        available, valid = await auth.validate_new_username(
             amodel.plugin_ctx, req.args.get('username'))
         return dict(available=available if available and valid else False, valid=valid)
 
@@ -131,7 +131,7 @@ async def sign_up_confirm_email(self, request):
         try:
             key = request.args.get('key')
             ans = dict(sign_up_url=self.create_url('user/sign_up_form', {}))
-            ans.update(auth.sign_up_confirm(self._plugin_ctx, key))
+            ans.update(await auth.sign_up_confirm(self._plugin_ctx, key))
             return ans
         except SignUpNeedsUpdateException as ex:
             logging.getLogger(__name__).warning(ex)
@@ -152,7 +152,7 @@ async def set_user_password(amodel, req, resp):
 
         if not amodel.uses_internal_user_pages():
             raise UserActionException(req.translate('This function is disabled.'))
-        logged_in = auth.validate_user(
+        logged_in = await auth.validate_user(
             amodel.plugin_ctx, req.session_get('user', 'user'), curr_passwd)
 
         if amodel.is_anonymous_id(logged_in['id']):
@@ -172,7 +172,7 @@ async def set_user_password(amodel, req, resp):
             fields['new_passwd2'] = False
             return ans
 
-        auth.update_user_password(amodel.plugin_ctx, req.session_get('user', 'id'), new_passwd)
+        await auth.update_user_password(amodel.plugin_ctx, req.session_get('user', 'id'), new_passwd)
         return ans
 
 
@@ -217,14 +217,14 @@ async def ajax_query_history(amodel, req, resp):
 @http_action(return_type='template', action_model=UserActionModel)
 async def ajax_get_toolbar(amodel, req, resp):
     with plugins.runtime.APPLICATION_BAR as ab:
-        return ab.get_contents(plugin_ctx=amodel.plugin_ctx, return_url=amodel.return_url)
+        return await ab.get_contents(plugin_ctx=amodel.plugin_ctx, return_url=amodel.return_url)
 
 
 @bp.route('/user/ajax_user_info')
 @http_action(return_type='json', action_model=UserActionModel)
 async def ajax_user_info(amodel, req, resp):
     with plugins.runtime.AUTH as auth:
-        user_info = auth.get_user_info(amodel.plugin_ctx)
+        user_info = await auth.get_user_info(amodel.plugin_ctx)
         if not amodel.user_is_anonymous():
             return {'user': user_info}
         else:
@@ -239,7 +239,7 @@ async def profile(amodel, req, resp):
     if not amodel.uses_internal_user_pages():
         raise UserActionException(req.translate('This function is disabled.'))
     with plugins.runtime.AUTH as auth:
-        user_info = auth.get_user_info(amodel.plugin_ctx)
+        user_info = await auth.get_user_info(amodel.plugin_ctx)
         if not amodel.user_is_anonymous():
             return dict(credentials_form=user_info, user_registered=True)
         else:

--- a/lib/views/user.py
+++ b/lib/views/user.py
@@ -176,11 +176,11 @@ async def set_user_password(amodel, req, resp):
         return ans
 
 
-def _load_query_history(
+async def _load_query_history(
         amodel: UserActionModel, user_id, offset, limit, from_date, to_date, q_supertype, corpname, archived_only):
     if plugins.runtime.QUERY_HISTORY.exists:
         with plugins.runtime.QUERY_HISTORY as qh:
-            rows = qh.get_user_queries(
+            rows = await qh.get_user_queries(
                 user_id,
                 amodel.cm,
                 offset=offset, limit=limit,
@@ -200,7 +200,7 @@ async def ajax_query_history(amodel, req, resp):
     query_supertype = req.args.get('query_supertype')
     corpname = req.args.get('corpname', None)
     archived_only = bool(int(req.args.get('archived_only', '0')))
-    rows = _load_query_history(
+    rows = await _load_query_history(
         amodel=amodel, q_supertype=query_supertype, corpname=corpname, from_date=None,
         user_id=req.session_get('user', 'id'), to_date=None, archived_only=archived_only, offset=offset,
         limit=limit)

--- a/public/app.py
+++ b/public/app.py
@@ -22,6 +22,7 @@ It can be run in two modes:
  2) within a WSGI-enabled web server (Gunicorn, uwsgi, Apache + mod_wsgi)
 """
 
+import asyncio
 import sys
 import os
 import wsgiref.util

--- a/public/ws_app.py
+++ b/public/ws_app.py
@@ -167,7 +167,7 @@ async def conc_cache_status_ws_handler(request: web.Request) -> web.WebSocketRes
     # check until finished
     while not ws.closed:
         try:
-            response = get_conc_cache_status(corp, params['conc_id'])
+            response = await get_conc_cache_status(corp, params['conc_id'])
         except Exception as e:
             response = {'error': str(e), 'finished': True}
         await ws.send_json(response)
@@ -181,12 +181,12 @@ async def conc_cache_status_ws_handler(request: web.Request) -> web.WebSocketRes
     return ws
 
 
-def get_conc_cache_status(corp: KCorpus, conc_id: str):
+async def get_conc_cache_status(corp: KCorpus, conc_id: str):
     cache_map = plugins.runtime.CONC_CACHE.instance.get_mapping(corp)
     q = []
     try:
         with plugins.runtime.QUERY_PERSISTENCE as qp:
-            data = qp.open(conc_id)
+            data = await qp.open(conc_id)
             q = data.get('q', [])
         cache_status = cache_map.get_calc_status(corp.subchash, data.get('q', []))
         if cache_status is None:  # conc is not cached nor calculated

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,8 @@ lxml >= 3.4
 Markdown >= 3.3.6
 openpyxl >= 3.0.5
 redis >= 4.2.0rc1
+aiomysql >= 0.0.22
+# TODO remove
 mysql-connector-python >= 8.0.28
 dataclasses-json >= 0.5.6
 couchdb >= 1.2

--- a/tests/mocks/mplugins.py
+++ b/tests/mocks/mplugins.py
@@ -57,8 +57,8 @@ class MockAuth(AbstractAuth):
     def is_administrator(self, user_id):
         return False
 
-    def permitted_corpora(self, user_dict):
+    async def permitted_corpora(self, user_dict):
         raise NotImplementedError()
 
-    def get_user_info(self, plugin_ctx):
+    async def get_user_info(self, plugin_ctx):
         raise NotImplementedError()


### PR DESCRIPTION
Integration DB is now mainly asynchronous
- `cursor()` and `connection()` are **async context managers** using connection pool
- `cursor_sync()` and `connection_sync()` are regular **context managers** using one time connection
- removed `execute`, `executemany`, `commit`, `start_transaction`, `rollback` - since we're using pool these should be handled through connections or cursors