### PR TITLE
pquery - replace multiprocessing variant with two alternative solutions

### DIFF
--- a/worker/general.py
+++ b/worker/general.py
@@ -250,8 +250,10 @@ async def clean_freqs_cache():
     return freq_calc.clean_freqs_cache()
 
 
-async def calc_merged_freqs(request_json, raw_queries, subcpath, user_id, collator_locale):
-    return await pquery.calc_merged_freqs(request_json, raw_queries, subcpath, user_id, collator_locale)
+async def calc_merged_freqs(worker, request_json, raw_queries, subcpath, user_id, collator_locale):
+    # TODO for performance testing switch between the two implementations
+    # return await pquery.calc_merged_freqs_worker(worker, request_json, raw_queries, subcpath, user_id, collator_locale)
+    return await pquery.calc_merged_freqs_threaded(worker, request_json, raw_queries, subcpath, user_id, collator_locale)
 
 # ----------------------------- DATA PRECALCULATION ---------------------------
 

--- a/worker/rqworker.py
+++ b/worker/rqworker.py
@@ -101,7 +101,7 @@ async def clean_freqs_cache():
 
 @as_sync
 async def calc_merged_freqs(request_json, raw_queries, subcpath, user_id, collator_locale):
-    return await general.calc_merged_freqs(request_json, raw_queries, subcpath, user_id, collator_locale)
+    return await general.calc_merged_freqs(worker, request_json, raw_queries, subcpath, user_id, collator_locale)
 
 # ----------------------------- DATA PRECALCULATION ---------------------------
 


### PR DESCRIPTION
- thread-based
- worker-based (Rq/Celery)

Now with most functions transformed to 'async' we cannot easily
schedule coroutine to work on a forked process (multiprocessing).