### PR TITLE
Fix shuffle operation form implementation (support ticket 2711)

### DIFF
--- a/public/files/js/models/mainMenu/index.ts
+++ b/public/files/js/models/mainMenu/index.ts
@@ -186,7 +186,7 @@ export class MainMenuModel extends StatelessModel<MainMenuModelState> {
         // here we have to make a kind of correction as traditionally, server
         // sends "save" menu items but starting from v0.16 we display charts
         // by default which means only the "Custom..." item
-        const [,customSaveItem] = List.find(([id,]) => id === 'menu-save', data) || [undefined, {customSaveItem: {items: []}}];
+        const [,customSaveItem] = List.find(([id,]) => id === 'menu-save', data) || [undefined, {items: []}];
         const freqsPrevItems = List.empty(customSaveItem.items) ? [] : [List.last(customSaveItem.items)];
         super(
             dispatcher,

--- a/public/files/js/models/query/actions.ts
+++ b/public/files/js/models/query/actions.ts
@@ -420,6 +420,12 @@ export class Actions {
         name: 'FILTER_FIRST_HITS_SUBMIT'
     };
 
+    static ShuffleFormSubmit:Action<{
+        opKey:string;
+    }> = {
+        name: 'SHUFFLE_FORM_SUBMIT'
+    }
+
     static ToggleQuerySuggestionWidget: Action<{
         formType:QueryFormType;
         sourceId:string;

--- a/public/files/js/models/query/formArgs.ts
+++ b/public/files/js/models/query/formArgs.ts
@@ -148,6 +148,9 @@ export interface FirstHitsFormArgs extends ConcFormArgs {
     doc_struct:string;
 }
 
+export interface ShuffleFormArgs extends ConcFormArgs {
+}
+
 export interface SampleFormArgsResponse extends SampleFormArgs, Kontext.AjaxResponse {}
 
 export interface ConcFormArgsResponse extends Kontext.AjaxResponse, ConcFormArgs {}
@@ -159,6 +162,7 @@ export interface ConcFormsInitialArgs {
     sample:SampleFormArgs;
     firsthits:FirstHitsFormArgs;
     switchmc:SwitchMainCorpArgs;
+    shuffle:ShuffleFormArgs;
 }
 
 

--- a/public/files/js/models/query/shuffle.ts
+++ b/public/files/js/models/query/shuffle.ts
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2022 Charles University in Prague, Faculty of Arts,
+ *                    Institute of the Czech National Corpus
+ * Copyright (c) 2022 Tomas Machalek <tomas.machalek@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; version 2
+ * dated June, 1991.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { IFullActionControl, StatefulModel } from 'kombo';
+import { Observable, of as rxOf } from 'rxjs';
+import { tap, map } from 'rxjs/operators';
+
+import { PageModel } from '../../app/page';
+import { Actions as MainMenuActions } from '../mainMenu/actions';
+import { Actions } from './actions';
+import { Actions as ConcActions } from '../../models/concordance/actions';
+import { AjaxConcResponse } from '../concordance/common';
+import { HTTP, List } from 'cnc-tskit';
+import { ShuffleFormArgs } from './formArgs';
+import { ConcFormTypes } from '../../types/kontext';
+
+
+interface ShuffleModelState {
+}
+
+
+export class ShuffleModel extends StatefulModel<ShuffleModelState> {
+
+    private readonly layoutModel:PageModel;
+
+    private readonly syncInitialArgs:ShuffleFormArgs;
+
+
+    constructor(
+        dispatcher:IFullActionControl,
+        layoutModel:PageModel,
+        syncInitialArgs:ShuffleFormArgs
+    ) {
+        super(
+            dispatcher,
+            {
+                docStructValues: {}
+            }
+        );
+        this.layoutModel = layoutModel;
+        this.syncInitialArgs = syncInitialArgs;
+
+        this.addActionHandler(
+            MainMenuActions.ApplyShuffle,
+            action => {
+                this.syncFrom(rxOf({...this.syncInitialArgs, ...action.payload})).subscribe({
+                    error: err => {
+                        this.layoutModel.showMessage('error',
+                            `Failed to synchronize ShuffleModel: ${err}`);
+                    }
+                })
+                this.emitChange();
+            }
+        );
+
+        this.addActionHandler(
+            Actions.ShuffleFormSubmit,
+            action => {
+                const concId = List.head(this.layoutModel.getConcArgs().q).substring(1);
+                this.submitForm(
+                    action.payload.opKey, concId
+
+                ).subscribe({
+                    next: data => {
+                        dispatcher.dispatch<typeof ConcActions.AddedNewOperation>({
+                            name: ConcActions.AddedNewOperation.name,
+                            payload: {
+                                concId: data.conc_persistence_op_id,
+                                data
+                            }
+                        });
+                    },
+                    error: error => {
+                        dispatcher.dispatch<typeof ConcActions.AddedNewOperation>({
+                            name: ConcActions.AddedNewOperation.name,
+                            error
+                        });
+                    }
+                });
+            }
+        );
+    }
+
+    getSubmitUrl(opKey:string, concId:string):string {
+        return this.layoutModel.createActionUrl(
+            'shuffle',
+            {
+                ...this.layoutModel.getConcArgs(),
+                q: ['~' + concId],
+                format: 'json'
+            }
+        );
+    }
+
+    submitForm(opKey:string, concId:string):Observable<AjaxConcResponse> {
+        return this.layoutModel.ajax$<AjaxConcResponse>(
+            HTTP.Method.GET,
+            this.getSubmitUrl(opKey, concId),
+            {}
+        );
+    }
+
+    syncFrom(fn:Observable<ShuffleFormArgs>):Observable<ShuffleFormArgs> {
+        return fn.pipe(
+            tap(
+                (data) => {
+                    if (data.form_type === ConcFormTypes.SHUFFLE) {
+                        this.emitChange();  // no real change needed here
+                    }
+                }
+            ),
+            map(
+                (data) => {
+                    if (data.form_type === ConcFormTypes.SHUFFLE) {
+                        return data;
+
+                    } else if (data.form_type === ConcFormTypes.LOCKED) {
+                        return null;
+
+                    } else {
+                        throw new Error('Cannot sync ShuffleModel - invalid form data type: ' + data.form_type);
+                    }
+                }
+            )
+        );
+    }
+}

--- a/public/files/js/pages/coll.ts
+++ b/public/files/js/pages/coll.ts
@@ -291,14 +291,7 @@ export class CollPage {
                 },
                 sortFormProps: {
                     formType: Kontext.ConcFormTypes.SORT,
-                    sortId: null,
-                },
-                shuffleFormProps: {
-                    formType: Kontext.ConcFormTypes.SHUFFLE,
-                    shuffleMinResultWarning: null,
-                    lastOpSize: null,
-                    operationIdx: null,
-                    shuffleSubmitFn:()=>undefined
+                    sortId: null
                 }
             }
         );

--- a/public/files/js/pages/freq.ts
+++ b/public/files/js/pages/freq.ts
@@ -295,13 +295,6 @@ class FreqPage {
                 sortFormProps: {
                     formType: Kontext.ConcFormTypes.SORT,
                     sortId: null,
-                },
-                shuffleFormProps: {
-                    formType: Kontext.ConcFormTypes.SHUFFLE,
-                    shuffleMinResultWarning: null,
-                    lastOpSize: null,
-                    operationIdx: null,
-                    shuffleSubmitFn:()=>undefined
                 }
             }
         );

--- a/public/files/js/pages/view.ts
+++ b/public/files/js/pages/view.ts
@@ -89,6 +89,7 @@ import { ConcSummaryModel } from '../models/concordance/summary';
 import * as formArgs from '../models/query/formArgs';
 import { DispersionResultModel } from '../models/dispersion/result';
 import { AnyTTSelection } from '../types/textTypes';
+import { ShuffleModel } from '../models/query/shuffle';
 
 
 export class QueryModels {
@@ -107,6 +108,7 @@ export class QueryModels {
     saveAsFormModel:QuerySaveAsFormModel;
     firstHitsModel:FirstHitsModel;
     queryHelpModel:QueryHelpModel;
+    shuffleModel:ShuffleModel;
 }
 
 interface RenderLinesDeps {
@@ -285,7 +287,8 @@ export class ViewPage {
             case 'quick_filter':
             case 'create_view':
             case 'filter_subhits':
-            case 'switch_main_corp': {
+            case 'switch_main_corp':
+            case 'shuffle': {
                 this.layoutModel.getHistory().replaceState(
                     'view',
                     this.layoutModel.getConcArgs(),
@@ -638,6 +641,14 @@ export class ViewPage {
         );
     }
 
+    private initShuffleForm():void {
+        this.queryModels.shuffleModel = new ShuffleModel(
+            this.layoutModel.dispatcher,
+            this.layoutModel,
+            this.concFormsInitialArgs.shuffle
+        );
+    }
+
     /**
      *
      */
@@ -733,15 +744,11 @@ export class ViewPage {
                 },
                 shuffleFormProps: {
                     formType: Kontext.ConcFormTypes.SHUFFLE,
+                    opKey: undefined,
                     lastOpSize: 0,
                     shuffleMinResultWarning: this.layoutModel.getConf<number>(
                         'ShuffleMinResultWarning'
-                    ),
-                    shuffleSubmitFn: () => {
-                        const args = this.layoutModel.getConcArgs();
-                        window.location.href = this.layoutModel.createActionUrl(
-                            'shuffle', args);
-                    }
+                    )
                 },
                 switchMcFormProps: {
                     formType: Kontext.ConcFormTypes.SWITCHMC,
@@ -1126,6 +1133,7 @@ export class ViewPage {
             this.setupHistoryOnPopState();
             this.initQueryForm(queryFormArgs, ttInitialData);
             this.initFirsthitsForm();
+            this.initShuffleForm();
             this.initFilterForm(this.layoutModel.qsuggPlugin, this.queryModels.firstHitsModel);
             this.initSortForm();
             this.initSwitchMainCorpForm();

--- a/public/files/js/views/query/miscActions.tsx
+++ b/public/files/js/views/query/miscActions.tsx
@@ -48,8 +48,8 @@ export interface ShuffleFormProps {
     formType:Kontext.ConcFormTypes.SHUFFLE;
     shuffleMinResultWarning:number;
     lastOpSize:number;
+    opKey:string;
     operationIdx?:number;
-    shuffleSubmitFn:()=>void;
 }
 
 export interface ShuffleFormState {
@@ -90,8 +90,8 @@ export function init(dispatcher:IActionDispatcher, he:Kontext.ComponentHelpers,
             });
         }
 
-        _handleSubmitEvent(evt) {
-            if (evt.key === undefined || evt.key === Keyboard.Value.ENTER) {
+        _handleSubmitEvent(evt:React.MouseEvent<HTMLButtonElement>|React.KeyboardEvent<HTMLFormElement>) {
+            if (evt['key'] === undefined || evt['key'] === Keyboard.Value.ENTER) {
                 if (this.props.operationIdx !== undefined) {
                     dispatcher.dispatch<typeof Actions.BranchQuery>({
                         name: Actions.BranchQuery.name,
@@ -143,6 +143,33 @@ export function init(dispatcher:IActionDispatcher, he:Kontext.ComponentHelpers,
                 isAutoSubmit: this.props.shuffleMinResultWarning > this.props.lastOpSize
                                 && this.props.operationIdx === undefined
             };
+
+            this.handleSubmit = this.handleSubmit.bind(this);
+        }
+
+        private handleSubmit(
+            evt:undefined|React.MouseEvent<HTMLButtonElement>|React.KeyboardEvent<HTMLFormElement>
+        ):void {
+            if (!evt || evt['key'] === undefined || evt['key'] === Keyboard.Value.ENTER) {
+                if (this.props.operationIdx !== undefined) {
+                    dispatcher.dispatch<typeof Actions.BranchQuery>({
+                        name: Actions.BranchQuery.name,
+                        payload: {operationIdx: this.props.operationIdx}
+                    });
+
+                } else {
+                    dispatcher.dispatch<typeof Actions.ShuffleFormSubmit>({
+                        name: Actions.ShuffleFormSubmit.name,
+                        payload: {
+                            opKey: this.props.opKey
+                        }
+                    });
+                }
+                if (evt) {
+                    evt.preventDefault();
+                    evt.stopPropagation();
+                }
+            }
         }
 
         _renderWarningState() {
@@ -155,7 +182,7 @@ export function init(dispatcher:IActionDispatcher, he:Kontext.ComponentHelpers,
                         {he.translate('query__shuffle_large_data_warn')}
                     </p>
                     <button type="button" className="default-button"
-                            onClick={()=>this.props.shuffleSubmitFn()}>
+                            onClick={this.handleSubmit}>
                         {he.translate('global__submit_anyway')}
                     </button>
                 </div>
@@ -173,7 +200,7 @@ export function init(dispatcher:IActionDispatcher, he:Kontext.ComponentHelpers,
                     <p>{he.translate('query__the_form_no_params_to_change')}.</p>
                     <p>
                         <button type="button" className="default-button"
-                                    onClick={()=>this.props.shuffleSubmitFn()}>
+                                    onClick={this.handleSubmit}>
                             {he.translate('global__proceed')}
                         </button>
                     </p>
@@ -196,7 +223,7 @@ export function init(dispatcher:IActionDispatcher, he:Kontext.ComponentHelpers,
         componentDidMount() {
             if (this.state.isAutoSubmit) {
                 window.setTimeout(() => {
-                    this.props.shuffleSubmitFn();
+                    this.handleSubmit(undefined);
                 }, 0);
             }
         }

--- a/public/files/js/views/query/overview/index.tsx
+++ b/public/files/js/views/query/overview/index.tsx
@@ -289,8 +289,8 @@ export function init({dispatcher, he, viewDeps, queryReplayModel,
                             shuffleMinResultWarning={props.shuffleMinResultWarning}
                             lastOpSize={props.resultSize}
                             operationIdx={props.operationIdx}
-                            formType={Kontext.ConcFormTypes.SHUFFLE}
-                            shuffleSubmitFn={()=>undefined} />;
+                            opKey={props.opKey}
+                            formType={Kontext.ConcFormTypes.SHUFFLE} />;
 
                 case Kontext.ConcFormTypes.SWITCHMC:
                     return <viewDeps.SwitchMainCorpForm {...props.editorProps}
@@ -450,20 +450,7 @@ export function init({dispatcher, he, viewDeps, queryReplayModel,
                 return props.sortFormProps;
 
             } else if (opId === 'f') {
-                return {
-                    formType: Kontext.ConcFormTypes.SHUFFLE,
-                    shuffleMinResultWarning: null,
-                    lastOpSize: null,
-                    operationIdx: opIdx,
-                    shuffleSubmitFn: () => {
-                        dispatcher.dispatch<typeof Actions.BranchQuery>({
-                            name: Actions.BranchQuery.name,
-                            payload: {
-                                operationIdx: opIdx
-                            }
-                        });
-                    }
-                }
+                return props.shuffleFormProps;
 
             } else if (opId === 'r') {
                 return {


### PR DESCRIPTION
We've been using a no-model aproach here which has been preventing the
operation from being used in "branch" operations etc. Now it has its
own model (even if its state has no attributes).