### PR TITLE
Improve/fix data format sent by liveattrs to masm

### DIFF
--- a/public/files/js/models/textTypes/common.ts
+++ b/public/files/js/models/textTypes/common.ts
@@ -123,9 +123,39 @@ export interface TTInitialData {
 }
 
 
-const typeIsSelected = (data:TextTypes.ExportedSelection, attr:string, v:string):boolean => {
+export const textTypeSelectionEquals = (sel:TextTypes.AnyExportedTTSelection, v:string):boolean => {
+    if (Array.isArray(sel)) {
+        return sel.indexOf(v) > -1;
+
+    } else if (typeof sel === 'string') {
+        return sel === v;
+
+    } else {
+        return sel.regexp === v;
+    }
+};
+
+
+export const extractTTSelectionValue = (sel:TextTypes.SingleValueExportedTTSelection):string => {
+    if (typeof sel === 'string') {
+        return sel;
+    }
+    return sel.regexp;
+}
+
+
+const textTypeValueIsSelected = (data:TextTypes.ExportedSelection, attr:string, v:string):boolean => {
     if (data.hasOwnProperty(attr)) {
-        return data[attr].indexOf(v) > -1;
+        const typeSelection = data[attr];
+        if (Array.isArray(typeSelection)) {
+            return List.find(item => item === v, typeSelection) !== undefined;
+
+        } else if (TextTypes.isExportedRegexpSelection(typeSelection)) {
+            return typeSelection.regexp === v;
+
+        } else {
+            return typeSelection === v;
+        }
     }
     return false;
 }
@@ -177,11 +207,11 @@ export function importInitialTTData(data:TTInitialData,
                     valItem => ({
                         value: valItem.v,
                         ident: valItem.v, // TODO what about bib items?
-                        selected: typeIsSelected(selectedItems, attrItem.name, valItem.v) || typeIsSelected(subcorpDefinition, attrItem.name, valItem.v) ?
+                        selected: textTypeValueIsSelected(selectedItems, attrItem.name, valItem.v) || textTypeValueIsSelected(subcorpDefinition, attrItem.name, valItem.v) ?
                             true : false,
-                        definesSubcorp: typeIsSelected(subcorpDefinition, attrItem.name, valItem.v) ?
+                        definesSubcorp: textTypeValueIsSelected(subcorpDefinition, attrItem.name, valItem.v) ?
                             true : false,
-                        locked: typeIsSelected(subcorpDefinition, attrItem.name, valItem.v) ?
+                        locked: textTypeValueIsSelected(subcorpDefinition, attrItem.name, valItem.v) ?
                             true : false,
                         availItems:valItem.xcnt,
                         // TODO here we expect that initial data

--- a/public/files/js/models/textTypes/selectionOps.ts
+++ b/public/files/js/models/textTypes/selectionOps.ts
@@ -85,9 +85,14 @@ export class TTSelOps {
         }
     }
 
-    static exportSelections(sel:TextTypes.AnyTTSelection, lockedOnesOnly:boolean, includeSubcorpDefinition:boolean):Array<string> {
+    static exportSelections(
+        sel:TextTypes.AnyTTSelection,
+        lockedOnesOnly:boolean,
+        includeSubcorpDefinition:boolean
+    ):Array<string>|TextTypes.ExportedRegexpSelection {
+
         if (sel.type === 'regexp') {
-            return [sel.textFieldValue];
+            return {regexp: sel.textFieldValue};
         }
         const filter = lockedOnesOnly ?
             List.filter<TextTypes.AttributeValue>(item => item.locked) :

--- a/public/files/js/plugins/mysqlLiveAttributes/models.ts
+++ b/public/files/js/plugins/mysqlLiveAttributes/models.ts
@@ -26,7 +26,7 @@ import { pipe, List, Dict, tuple, HTTP } from 'cnc-tskit';
 import * as Kontext from '../../types/kontext';
 import * as TextTypes from '../../types/textTypes';
 import * as PluginInterfaces from '../../types/plugins';
-import { SelectionFilterMap } from '../../models/textTypes/common';
+import { extractTTSelectionValue, SelectionFilterMap } from '../../models/textTypes/common';
 import { Actions as TTActions } from '../../models/textTypes/actions';
 import { Actions as QueryActions } from '../../models/query/actions';
 import { Actions as SubcActions } from '../../models/subcorp/actions';
@@ -617,7 +617,9 @@ export class LiveAttrsModel extends StatelessModel<LiveAttrsModelState> implemen
                                     type: 'encoded'
                                 } :
                                 {
-                                    selections: Array.isArray(sels) ? sels : [sels],
+                                    selections: Array.isArray(sels) ?
+                                        sels :
+                                        [extractTTSelectionValue(sels)],
                                     type: 'default'
                                 }
                             )

--- a/public/files/js/types/textTypes.ts
+++ b/public/files/js/types/textTypes.ts
@@ -18,7 +18,6 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-import { IModel } from 'kombo';
 import { WidgetView } from '../models/textTypes/common'; // TODO this breaks meaning of the 'common' module
 
 
@@ -125,7 +124,21 @@ export interface RegexpAttributeSelection {
 export type AnyTTSelection = TextInputAttributeSelection|FullAttributeSelection|
         RegexpAttributeSelection;
 
-export type ExportedSelection = {[sca:string]:Array<string>|string};
+
+export interface ExportedRegexpSelection {
+    regexp:string
+};
+
+export type SingleValueExportedTTSelection = string|ExportedRegexpSelection;
+
+export type AnyExportedTTSelection = Array<string>|SingleValueExportedTTSelection;
+
+export function isExportedRegexpSelection(v:AnyExportedTTSelection):v is ExportedRegexpSelection {
+    return typeof v['regexp'] === 'string';
+}
+
+
+export type ExportedSelection = {[sca:string]:AnyExportedTTSelection};
 
 
 /**

--- a/public/files/js/views/freqs/twoDimension/table2d/index.tsx
+++ b/public/files/js/views/freqs/twoDimension/table2d/index.tsx
@@ -806,17 +806,33 @@ export function init(
                         {'\u00a0'}
                         {he.translate('freq__ct_current_adhoc_subc_is')}:
                         {'\u00a0'}
-                        {Object.keys(props.concSelectedTextTypes).map(v => {
-                            const data = props.concSelectedTextTypes[v];
-                            const values = Array.isArray(data) ? data : [data];
+                        {pipe(
+                            props.concSelectedTextTypes,
+                            Dict.keys(),
+                            List.map(v => {
+                                const data = props.concSelectedTextTypes[v];
+                                const getValues = () => {
+                                    if (Array.isArray(data)) {
+                                        return data;
 
-                            return (
-                                <span key={v}>
-                                    <strong>{v}</strong>
-                                    {' \u2208 {' + List.map<string|number, string>(v => `"${v}"`, values).join(', ') + '}'}
-                                </span>
-                            );
-                        })}
+                                    } else if (TextTypes.isExportedRegexpSelection(data)) {
+                                        return [data.regexp];
+
+                                    } else {
+                                        return [data];
+                                    }
+                                };
+
+                                return (
+                                    <span key={v}>
+                                        <strong>{v}</strong>
+                                        {' \u2208 {' }
+                                        {List.map<string|number, string>(v => `"${v}"`, getValues()).join(', ')}
+                                        {'}'}
+                                    </span>
+                                );
+                            })
+                        )}
                     </p>
                 );
             }


### PR DESCRIPTION
we needed to flag somehow regexp values so we can apply regexp matching only when necessary