### PR TITLE
Handle cutoff properly:

### DIFF
--- a/lib/action/argmapping/__init__.py
+++ b/lib/action/argmapping/__init__.py
@@ -216,6 +216,7 @@ class Args(UserActionArgs):
     structs: str = field(default='', metadata=mk_metdata(
         Persistence.PERSISTENT, comma_separated_to_js))
     q: List[str] = field(default_factory=list, metadata=mk_metdata())
+    cutoff: int = field(default=0, metadata=mk_metdata())
     wlsendmail: str = field(default='', metadata=mk_metdata())
     cup_hl: str = field(default='q', metadata=mk_metdata(Persistence.PERSISTENT))
     structattrs: List[str] = field(

--- a/lib/action/argmapping/conc/query.py
+++ b/lib/action/argmapping/conc/query.py
@@ -52,7 +52,7 @@ class _QueryFormArgs:
     # for bibliography structattr - maps from hidden ids to visible titles (this is optional)
     bib_mapping: Dict[str, str] = field(default_factory=dict)
 
-    sample_size: int = -1
+    cutoff: int = 0
     """defines a cut-off for large concordances"""
 
 
@@ -135,7 +135,7 @@ class QueryFormArgs(ConcFormArgs[_QueryFormArgs]):
         self.data.fc_pos_wsize = ctx.get('fc_pos_wsize', self.data.fc_pos_wsize)
         self.data.fc_pos = ctx.get('fc_pos', self.data.fc_pos)
         self.data.selected_text_types = data.get('text_types', {})
-        self.data.sample_size = data.get('sample_size', None)
+        self.data.cutoff = data.get('cutoff', 0)
 
     async def _add_corpus_metadata(self, corpus_id: str):
         with plugins.runtime.CORPARCH as ca, plugins.runtime.TAGHELPER as th:

--- a/lib/action/model/concordance/__init__.py
+++ b/lib/action/model/concordance/__init__.py
@@ -22,6 +22,7 @@ import re
 import urllib.parse
 from typing import Any, Dict, List, Optional, Tuple, Union
 import hashlib
+from collections import OrderedDict
 
 import conclib
 import plugins
@@ -82,6 +83,13 @@ class ConcActionModel(CorpusActionModel):
                 self._active_q_data.get('lines_groups', []))
 
     async def fetch_prev_query(self, query_type: str) -> Optional[QueryFormArgs]:
+        """
+        Based on information about prev. query ID (and type) stored in session,
+        load full form data of the previous query.
+
+        In case the prev. operation is based on the same corpus, redirect
+        immediately to the '/query' action with respective arguments.
+        """
         curr = self._req.ctx.session.get('last_search', {})
         last_op = curr.get(query_type, None)
         if last_op:
@@ -95,8 +103,7 @@ class ConcActionModel(CorpusActionModel):
                 curr_subcorp = self.args.usesubcorp
 
                 if prev_corpora and len(curr_corpora) == 1 and prev_corpora[0] == curr_corpora[0]:
-                    args = [('corpname', prev_corpora[0])] + [('align', a)
-                                                              for a in prev_corpora[1:]]
+                    args = [('corpname', prev_corpora[0])] + [('align', a) for a in prev_corpora[1:]]
 
                     subcorpora = await subc_arch.list(
                         self._req.ctx.session.get('user')['id'], SubcListFilterArgs(), corpname=prev_corpora[0])
@@ -126,9 +133,9 @@ class ConcActionModel(CorpusActionModel):
                     return qf_args
         return None
 
-    def add_conc_form_args(self, item: ConcFormArgs) -> None:
+    def set_curr_conc_form_args(self, item: ConcFormArgs) -> None:
         """
-        Add persistent form arguments for a currently processed
+        Set persistent form arguments for the currently processed
         action. The data are used in two ways:
         1) as a source of values when respective JS models are instantiated
         2) when conc persistence automatic save procedure
@@ -173,12 +180,17 @@ class ConcActionModel(CorpusActionModel):
         tpl_data['num_lines_in_groups'] = len(self._lines_groups)
         tpl_data['lines_groups_numbers'] = tuple(set([v[2] for v in self._lines_groups]))
 
-    def _update_output_with_conc_params(self, op_id: Optional[str], tpl_data: Dict[str, Any]) -> None:
+    def _output_last_op_id(self, op_id: Optional[str], tpl_data: Dict[str, Any]) -> None:
         """
-        Updates template data dictionary tpl_data with stored operation values.
+        Update template data dictionary tpl_data with stored concordance operation values.
+        In case the operation is new (i.e. something user just submitted from a respective
+        form), replace temporary '__latest__' ID with actual ID obtained from conc_persistence
+        plug-in.
+
+        Note: the actual op. form data is accessed via '_active_q_data' property
 
         arguments:
-        op_id -- unique operation ID
+        op_id -- unique operation ID as provided by conc_persistence plug-in
         tpl_data -- a dictionary used along with HTML template to render the output
         """
         if plugins.runtime.QUERY_PERSISTENCE.exists:
@@ -205,8 +217,9 @@ class ConcActionModel(CorpusActionModel):
         self.update_output_with_group_info(tpl_data)
 
         if len(self._lines_groups) > 0:
-            self.disabled_menu_items += (MainMenu.FILTER, MainMenu.CONCORDANCE('sorting'),
-                                         MainMenu.CONCORDANCE('shuffle'), MainMenu.CONCORDANCE('sample'))
+            self.disabled_menu_items += (
+                MainMenu.FILTER, MainMenu.CONCORDANCE('sorting'),
+                MainMenu.CONCORDANCE('shuffle'), MainMenu.CONCORDANCE('sample'))
 
     def acknowledge_auto_generated_conc_op(self, q_idx: int, query_form_args: ConcFormArgs) -> None:
         """
@@ -251,7 +264,7 @@ class ConcActionModel(CorpusActionModel):
                 history_ts = None
             for fn in self._on_query_store:
                 fn(next_query_keys, history_ts, resp.result)
-            self._update_output_with_conc_params(
+            self._output_last_op_id(
                 next_query_keys[-1] if len(next_query_keys) else None, resp.result)
 
     async def _store_conc_params(self) -> Tuple[List[str], Optional[int]]:
@@ -285,31 +298,31 @@ class ConcActionModel(CorpusActionModel):
     def select_current_aligned_corpora(self, active_only: bool) -> List[str]:
         return self.get_current_aligned_corpora() if active_only else self.get_available_aligned_corpora()
 
-    async def attach_query_params(
-            self, tpl_out: Dict[str, Any], query: Optional[QueryFormArgs] = None,
-            filter: Optional[FilterFormArgs] = None, sort: Optional[SortFormArgs] = None,
-            sample: Optional[SampleFormArgs] = None, shuffle: Optional[ShuffleFormArgs] = None,
-            firsthits: Optional[FirstHitsFilterFormArgs] = None) -> None:
+    async def export_query_forms(self, tpl_out: Dict[str, Any]) -> List[ConcFormArgs]:
         """
-        Attach data required by client-side forms which are
+        Export  data required by client-side forms which are
         part of the current query pipeline (i.e. initial query, filters,
-        sorting, samples,...). If any of query, filter,..., firsthits is provided than
-        it is used instead of the default variant of the form.
+        sorting, samples,...).
+
+        Also export query_overview which is a list of Manatee arguments for
+        each operation with attached concordance persistence IDs. The 'query_overview'
+        is the only data structure keeping order of operations (directly; otherwise
+        forms and their 'prev_id' can be theoretically used to rebuild the chain).
         """
         corpus_info = await self.get_corpus_info(self.args.corpname)
         tpl_out['metadata_desc'] = corpus_info.metadata.desc
         tpl_out['input_languages'] = {}
         tpl_out['input_languages'][getattr(self.args, 'corpname')] = corpus_info.collator_locale
 
-        conc_forms_args: Dict[str, Dict[str, Any]] = {}
+        conc_forms_args: OrderedDict[str, Dict[str, Any]] = OrderedDict()
+        query_overview = await self.concdesc_json()
         if self._active_q_data is not None and 'lastop_form' in self._active_q_data:
             op_key = self._active_q_data['id']
-            conc_forms_args[op_key] = (await build_conc_form_args(
-                self.plugin_ctx,
-                self._active_q_data.get('corpora', []),
-                self._active_q_data['lastop_form'],
-                op_key
-            )).to_dict()
+            with plugins.runtime.QUERY_PERSISTENCE as qp:
+                pipeline = await qp.load_pipeline_ops(self.plugin_ctx, op_key, build_conc_form_args)
+                for i, item in enumerate(pipeline):
+                    conc_forms_args[item.op_key] = item.to_dict()
+                    query_overview[i].conc_persistence_op_id = item.op_key
         # Attach new form args added by the current action.
         if len(self._auto_generated_conc_ops) > 0:
             conc_forms_args['__latest__'] = self._auto_generated_conc_ops[-1][1].to_dict()
@@ -320,16 +333,21 @@ class ConcActionModel(CorpusActionModel):
 
         corpora = self.select_current_aligned_corpora(active_only=True)
         tpl_out['conc_forms_initial_args'] = dict(
-            query=query.to_dict() if query is not None else (await QueryFormArgs.create(
+            query=(await QueryFormArgs.create(
                 plugin_ctx=self.plugin_ctx, corpora=corpora, persist=False)).to_dict(),
-            filter=filter.to_dict() if filter is not None else (await FilterFormArgs.create(
+            filter=(await FilterFormArgs.create(
                 plugin_ctx=self.plugin_ctx, maincorp=getattr(self.args, 'maincorp') if getattr(
                     self.args, 'maincorp') else getattr(self.args, 'corpname'), persist=False)).to_dict(),
-            sort=sort.to_dict() if sort is not None else SortFormArgs(persist=False).to_dict(),
-            sample=sample.to_dict() if sample is not None else SampleFormArgs(persist=False).to_dict(),
-            shuffle=shuffle.to_dict() if shuffle is not None else ShuffleFormArgs(persist=False).to_dict(),
-            firsthits=firsthits.to_dict() if firsthits is not None else FirstHitsFilterFormArgs(
+            sort=SortFormArgs(persist=False).to_dict(),
+            sample=SampleFormArgs(persist=False).to_dict(),
+            shuffle=ShuffleFormArgs(persist=False).to_dict(),
+            firsthits=FirstHitsFilterFormArgs(
                 persist=False, doc_struct=self.corp.get_conf('DOCSTRUCTURE')).to_dict())
+        tpl_out['query_overview'] = [x.to_dict() for x in query_overview]
+        if len(query_overview) > 0:
+            tpl_out['page_title'] = '{0} / {1}'.format(
+                self.corp.human_readable_corpname, tpl_out['query_overview'][0]['nicearg'])
+        return [x for x in conc_forms_args.values()]
 
     async def add_globals(self, app, action_props, result):
         """
@@ -341,6 +359,7 @@ class ConcActionModel(CorpusActionModel):
         result['conc_dashboard_modules'] = settings.get_list('global', 'conc_dashboard_modules')
         conc_args = self.get_mapped_attrs(ConcArgsMapping)
         conc_args['q'] = [q for q in result.get('Q')]
+        conc_args['cutoff'] = self.args.cutoff
         result['Globals'] = conc_args
         return result
 
@@ -554,8 +573,11 @@ class ConcActionModel(CorpusActionModel):
                     fullsize=fullsize, finished=conc.finished())
 
     async def concdesc_json(self):
+        """
+        Return encoded query description (i.e. just Manatee args, no form info)
+        """
         out_list: List[ConcDescJsonItem] = []
-        conc_desc = await conclib.get_conc_desc(corpus=self.corp, q=self.args.q)
+        conc_desc = await conclib.get_conc_desc(corpus=self.corp, q=self.args.q, cutoff=self.args.cutoff)
 
         def nicearg(arg):
             args = arg.split('"')
@@ -588,12 +610,6 @@ class ConcActionModel(CorpusActionModel):
                 size=op_item.size,
                 fullsize=op_item.fullsize))
         return out_list
-
-    async def attach_query_overview(self, out):
-        out['query_overview'] = [x.to_dict() for x in (await self.concdesc_json())]
-        if len(out['query_overview']) > 0:
-            out['page_title'] = '{0} / {1}'.format(
-                self.corp.human_readable_corpname, out['query_overview'][0]['nicearg'])
 
     @staticmethod
     def filter_lines(data, pnfilter):

--- a/lib/action/model/corpus.py
+++ b/lib/action/model/corpus.py
@@ -43,7 +43,6 @@ from action.response import KResponse
 from corplib.abstract import AbstractKCorpus
 from corplib.corpus import KCorpus
 from corplib.fallback import EmptyCorpus, ErrorCorpus
-from corplib.subcorpus import SubcorpusRecord
 from main_menu.model import EventTriggeringItem, MainMenu
 from plugin_types.corparch.corpus import (
     BrokenCorpusInfo, CorpusInfo, StructAttrInfo)
@@ -51,8 +50,8 @@ from texttypes.model import TextTypes
 
 T = TypeVar('T')
 
-PREFLIGHT_THRESHOLD_IPM = 5_000
-PREFLIGHT_MIN_LARGE_CORPUS = 100_000_00
+PREFLIGHT_THRESHOLD_IPM = 200_000
+PREFLIGHT_MIN_LARGE_CORPUS = 100_000_000
 
 
 class CorpusActionModel(UserActionModel):
@@ -219,14 +218,6 @@ class CorpusActionModel(UserActionModel):
 
     def clear_prev_conc_params(self):
         self._active_q_data = None
-
-    def get_curr_conc_args(self):
-        args = self.get_mapped_attrs(ConcArgsMapping)
-        if self._q_code:
-            args['q'] = f'~{self._q_code}'
-        else:
-            args['q'] = [q for q in self.args.q]
-        return args
 
     async def _check_corpus_access(self, req_args: Union[RequestArgsProxy, JSONRequestArgsProxy], action_props: ActionProps) -> Tuple[Union[str, None], str]:
         """
@@ -477,7 +468,6 @@ class CorpusActionModel(UserActionModel):
         corp_info = await self.get_corpus_info(getattr(self.args, 'corpname'))
         result['bib_conf'] = corp_info.metadata
         result['simple_query_default_attrs'] = corp_info.simple_query_default_attrs
-        result['corp_sample_size'] = corp_info.sample_size
         if corp_info.preflight_subcorpus:
             result['conc_preflight'] = dict(
                 corpname=corp_info.preflight_subcorpus.corpus_name,

--- a/lib/action/model/pquery.py
+++ b/lib/action/model/pquery.py
@@ -55,13 +55,16 @@ class ParadigmaticQueryActionModel(CorpusActionModel):
             self._plugin_ctx = PQueryPluginCtx(self, self._req, self._resp, self._plg_shared)
         return self._plugin_ctx
 
-    async def load_conc_queries(self, conc_ids: List[str], corpus_id: str,
-                                form_type: str) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+    async def load_conc_queries(
+            self, conc_ids: List[str], corpus_id: str, form_type: str) -> Tuple[Dict[str, Any], Dict[str, Any]]:
         """
-        Load both conc. query forms and respective raw Manatee queries
+        Load both conc. query forms and respective raw Manatee queries for provided
+        list of concordance operation IDs.
 
         form_type is either 'query' or 'filter'
         """
+        if form_type not in ('query', 'filter',):
+            raise RuntimeError('load_conc_queries requires either query or filter for type')
         forms = {}
         raw_queries = {}
         with plugins.runtime.QUERY_PERSISTENCE as qs:

--- a/lib/action/model/user.py
+++ b/lib/action/model/user.py
@@ -397,7 +397,6 @@ class UserActionModel(BaseActionModel, AbstractUserModel):
         self.configure_auth_urls(result)
         result['conc_url_ttl_days'] = None
         result['corpus_ident'] = {}
-        result['corp_sample_size'] = None
         result['Globals'] = {}
         result['base_attr'] = BaseActionModel.BASE_ATTR
         result['user_info'] = self._req.ctx.session.get('user', {'fullname': None})

--- a/lib/bgcalc/coll_calc.py
+++ b/lib/bgcalc/coll_calc.py
@@ -55,18 +55,18 @@ class CollCalcArgs:
     subcorpus_id: Optional[str]
     subcorpora_dir: Optional[str]
     cache_path: Optional[str] = field(default=None)
-    samplesize: int = field(default=0)
+    cutoff: int = field(default=0)
 
 
 class CollCalcCache(object):
 
-    def __init__(self, corpname, subcname, subcpath, user_id, q, samplesize=0):
+    def __init__(self, corpname, subcname, subcpath, user_id, q, cutoff=0):
         self._corpname = corpname
         self._subcname = subcname
         self._subcpath = subcpath
         self._user_id = user_id
         self._q = q
-        self._samplesize = samplesize
+        self.cutoff = cutoff
 
     def _cache_file_path(self, cattr, csortfn, cbgrfns, cfromw, ctow, cminbgr, cminfreq):
         v = f'{self._corpname}{self._subcname}{self._user_id}{"".join(self._q)}{cattr}{csortfn}{cbgrfns}{cfromw}{ctow}{cminbgr}{cminbgr}{cminfreq}'
@@ -152,7 +152,7 @@ async def calculate_colls(coll_args: CollCalcArgs) -> CalculateCollsResult:
     collend = collstart + coll_args.citemsperpage
     cache = CollCalcCache(
         corpname=coll_args.corpname, subcname=coll_args.subcorpus_id, subcpath=coll_args.subcorpora_dir,
-        user_id=coll_args.user_id, q=coll_args.q, samplesize=coll_args.samplesize)
+        user_id=coll_args.user_id, q=coll_args.q, cutoff=coll_args.cutoff)
     collocs, cache_path = await cache.get(
         cattr=coll_args.cattr, csortfn=coll_args.csortfn, cbgrfns=coll_args.cbgrfns,
         cfromw=coll_args.cfromw, ctow=coll_args.ctow, cminbgr=coll_args.cminbgr,

--- a/lib/bgcalc/freqs/types.py
+++ b/lib/bgcalc/freqs/types.py
@@ -38,7 +38,7 @@ class FreqCalcArgs:
     subcname: Optional[str] = None
     subcpath: Optional[str] = None
     fpage: Optional[int] = 1  # ??
-    samplesize: Optional[int] = 0
+    cutoff: Optional[int] = 0
     q: Optional[List[str]] = field(default_factory=list)
 
 

--- a/lib/bgcalc/pquery/__init__.py
+++ b/lib/bgcalc/pquery/__init__.py
@@ -52,7 +52,7 @@ def create_freq_calc_args(
         freq_sort='freq',
         pagesize=10000,  # TODO
         fmaxitems=10000,
-        samplesize=0,
+        cutoff=0,
         flimit=flimit_override if flimit_override is not None else pquery.min_freq,
         q=raw_queries[conc_id],
         collator_locale=collator_locale,

--- a/lib/conclib/__init__.py
+++ b/lib/conclib/__init__.py
@@ -65,10 +65,11 @@ class ConcDescJsonItem:
     tourl: str
     size: int
     fullsize: int
-    sample_size: Optional[int] = None
+    conc_persistence_op_id: Optional[str] = None
 
 
-async def get_conc_desc(corpus: AbstractKCorpus, q=None, translate=True, skip_internals=True, translator=lambda x: x):
+async def get_conc_desc(
+        corpus: AbstractKCorpus, q=None, cutoff=0, translate=True, skip_internals=True, translator=lambda x: x):
     """
     arguments:
     corpus -- a KCorpus instance
@@ -80,7 +81,7 @@ async def get_conc_desc(corpus: AbstractKCorpus, q=None, translate=True, skip_in
     q = tuple(q)
 
     async def get_size(pos):
-        return await cache_map.get_stored_size(corpus.cache_key, q[:pos + 1])
+        return await cache_map.get_stored_size(corpus.cache_key, q[:pos + 1], cutoff)
 
     def is_aligned_op(query_items, pos):
         return (query_items[pos].startswith('x-') and query_items[pos + 1] == 'p0 0 1 []' and

--- a/lib/conclib/calc/__init__.py
+++ b/lib/conclib/calc/__init__.py
@@ -68,12 +68,13 @@ async def del_silent(path: str):
         logging.getLogger(__name__).warning(f'del_silent problem: {ex} (file: {path}')
 
 
-async def cancel_conc_task(cache_map: AbstractConcCache, corp_cache_key: Optional[str], q: Tuple[str, ...]):
+async def cancel_conc_task(
+        cache_map: AbstractConcCache, corp_cache_key: Optional[str], q: Tuple[str, ...], cutoff: int):
     """
     Removes conc. cache entry and also a respective calculation task (silently).
     """
-    cachefile = await cache_map.readable_cache_path(corp_cache_key, q)
-    status = await cache_map.get_calc_status(corp_cache_key, q)
+    cachefile = await cache_map.readable_cache_path(corp_cache_key, q, cutoff)
+    status = await cache_map.get_calc_status(corp_cache_key, q, cutoff)
     if status:
         try:
             if status.task_id:
@@ -81,11 +82,16 @@ async def cancel_conc_task(cache_map: AbstractConcCache, corp_cache_key: Optiona
                 worker.control.revoke(status.task_id, terminate=True, signal='SIGKILL')
         except (IOError, CalcTaskNotFoundError):
             pass
-    await cache_map.del_entry(corp_cache_key, q)
+    await cache_map.del_entry(corp_cache_key, q, cutoff)
     await del_silent(cachefile)
 
 
-async def wait_for_conc(cache_map: AbstractConcCache, q: Tuple[str, ...], corp_cache_key: Optional[str], minsize: int) -> bool:
+async def wait_for_conc(
+        cache_map: AbstractConcCache,
+        corp_cache_key: Optional[str],
+        q: Tuple[str, ...],
+        cutoff: int,
+        minsize: int) -> bool:
     """
     Find a conc. calculation record in cache (matching provided corp_cache_key and query)
     and wait until a result is available. The behavior is modified by 'minsize' (see below).
@@ -99,21 +105,25 @@ async def wait_for_conc(cache_map: AbstractConcCache, q: Tuple[str, ...], corp_c
     time_limit = 7 if minsize >= 0 else 20   # 7 => ~2s, 20 => ~19s
     t0 = t1 = time.time()
     i = 1
-    has_min_result, finished = await _check_result(cache_map, q, corp_cache_key, minsize)
+    has_min_result, finished = await _check_result(cache_map, corp_cache_key, q, cutoff, minsize)
     while not (finished or has_min_result) and t1 - t0 < time_limit:
         time.sleep(i * 0.1)
         i += 1
         t1 = time.time()
-        has_min_result, finished = await _check_result(cache_map, q, corp_cache_key, minsize)
+        has_min_result, finished = await _check_result(cache_map, corp_cache_key, q, cutoff, minsize)
     if not has_min_result:
         if finished:  # cache vs. filesystem mismatch
-            await cache_map.del_entry(corp_cache_key, q)
+            await cache_map.del_entry(corp_cache_key, q, cutoff)
         return False
     return True
 
 
-async def _check_result(cache_map: AbstractConcCache, q: Tuple[str, ...], corp_cache_key: Optional[str],
-                        minsize: int) -> Tuple[bool, bool]:
+async def _check_result(
+        cache_map: AbstractConcCache,
+        corp_cache_key: Optional[str],
+        q: Tuple[str, ...],
+        cutoff: int,
+        minsize: int) -> Tuple[bool, bool]:
     """
     Check for result status while validating calculation
     status. In case of an error an Exception can be thrown.
@@ -130,26 +140,27 @@ async def _check_result(cache_map: AbstractConcCache, q: Tuple[str, ...], corp_c
     In case the calculation finished due to an error
     the function throws a ConcCalculationStatusException.
     """
-    status = await cache_map.get_calc_status(corp_cache_key, q)
+    status = await cache_map.get_calc_status(corp_cache_key, q, cutoff)
     if status is None:
         return False, False
     status.check_for_errors(TASK_TIME_LIMIT)
     if status.error is not None:
-        await cache_map.del_full_entry(corp_cache_key, q)
+        await cache_map.del_full_entry(corp_cache_key, q, cutoff)
         raise status.error
     return status.has_some_result(minsize=minsize), status.finished
 
 
 async def require_existing_conc(
         corp: AbstractKCorpus,
-        q: Union[Tuple[str, ...], List[str]]) -> PyConc:
+        q: Union[Tuple[str, ...], List[str]],
+        cutoff: int) -> PyConc:
     """
     Load a cached concordance based on a provided corpus and query.
     If nothing is found, ConcNotFoundException is thrown.
     """
     corpus_factory = CorpusFactory()
     cache_map = plugins.runtime.CONC_CACHE.instance.get_mapping(corp)
-    status = await cache_map.get_calc_status(corp.cache_key, q)
+    status = await cache_map.get_calc_status(corp.cache_key, q, cutoff)
     if status is None:
         raise ConcNotFoundException('Concordance not found: {}'.format(', '.join(q)))
     if status.finished and status.readable:
@@ -167,7 +178,7 @@ async def require_existing_conc(
 
 
 async def find_cached_conc_base(
-        corp: AbstractKCorpus, corp_cache_key: Optional[str], q: Tuple[str, ...],
+        corp: AbstractKCorpus, q: Tuple[str, ...], cutoff: int,
         minsize: int) -> Tuple[Optional[int], Union[PyConc, InitialConc]]:
     """
     Load a concordance from cache starting from a complete operation q[:],
@@ -185,17 +196,17 @@ async def find_cached_conc_base(
     start_time = time.time()
     cache_map = plugins.runtime.CONC_CACHE.instance.get_mapping(corp)
     await cache_map.ensure_writable_storage()
-    calc_status = await cache_map.get_calc_status(corp_cache_key, q)
+    calc_status = await cache_map.get_calc_status(corp.cache_key, q, cutoff)
     if calc_status:
         if calc_status.error is None:
             if (calc_status.created - (await corp.corp_mtime)) < 0:
                 logging.getLogger(__name__).warning(
                     'Removed outdated cache file (older than corpus indices)')
-                await cache_map.del_full_entry(corp_cache_key, q)
+                await cache_map.del_full_entry(corp.cache_key, q, cutoff)
         else:
             logging.getLogger(__name__).warning(
                 'Removed failed calculation cache record (error: {0}'.format(calc_status.error))
-            await cache_map.del_full_entry(corp_cache_key, q)
+            await cache_map.del_full_entry(corp.cache_key, q, cutoff)
             raise calc_status.normalized_error
 
     if _contains_shuffle_seq(q):
@@ -208,20 +219,20 @@ async def find_cached_conc_base(
     # try to find the most complete cached operation
     # (e.g. query + filter + sample)
     for i in range(srch_from, 0, -1):
-        cache_path = await cache_map.readable_cache_path(corp_cache_key, q[:i])
+        cache_path = await cache_map.readable_cache_path(corp.cache_key, q[:i], cutoff)
         # now we know that someone already calculated the conc (but it might not be finished yet)
         if cache_path:
             try:
                 ready = await wait_for_conc(
-                    cache_map=cache_map, corp_cache_key=corp_cache_key, q=q[:i], minsize=minsize)
+                    cache_map=cache_map, corp_cache_key=corp.cache_key, q=q[:i], cutoff=cutoff, minsize=minsize)
                 if not ready:
                     if minsize != 0:
-                        await cancel_conc_task(cache_map, corp_cache_key, q[:i])
+                        await cancel_conc_task(cache_map, corp.cache_key, q[:i], cutoff)
                         logging.getLogger(__name__).warning(
                             'Removed unfinished concordance cache record due to exceeded time limit')
                     continue
                 _, finished = await _check_result(
-                    cache_map=cache_map, corp_cache_key=corp_cache_key, q=q[:i], minsize=minsize)
+                    cache_map=cache_map, corp_cache_key=corp.cache_key, q=q[:i], cutoff=cutoff, minsize=minsize)
                 if finished:
                     mcorp = corp
                     for qq in reversed(q[:i]):  # find the right main corp, if aligned
@@ -232,7 +243,7 @@ async def find_cached_conc_base(
             except (ConcCalculationStatusException, manatee.FileAccessError) as ex:
                 logging.getLogger(__name__).error(
                     f'Failed to use cached concordance for {q[:i]}: {ex}')
-                await cancel_conc_task(cache_map, corp_cache_key, q[:i])
+                await cancel_conc_task(cache_map, corp.cache_key, q[:i], cutoff)
                 continue
             ans = (i, conc)
             break
@@ -250,7 +261,14 @@ class ConcCalculation(GeneralWorker):
         """
         super().__init__(task_id=task_id, cache_factory=cache_factory)
 
-    async def run(self, initial_args, subc_root, corpus_ident: Union[str, SubcorpusRecord], corp_cache_key, query, samplesize):
+    async def run(
+            self,
+            initial_args,
+            subc_root,
+            corpus_ident: Union[str, SubcorpusRecord],
+            corp_cache_key,
+            query,
+            cutoff):
         """
         initial_args -- a dict(cachefile=..., already_running=...)
         subc_dirs -- a list of directories where to look for subcorpora
@@ -258,7 +276,7 @@ class ConcCalculation(GeneralWorker):
         subc_name -- subcorpus name (should be None if not present)
         corp_cache_key -- an identifier of current subcorpus (None if no subcorpus is in use)
         query -- a tuple/list containing current query
-        samplesize -- row limit
+        cutoff -- row limit
         """
         cache_map = None
         try:
@@ -268,29 +286,38 @@ class ConcCalculation(GeneralWorker):
             if not initial_args['already_running']:
                 # The conc object bellow is asynchronous; i.e. you obtain it immediately but it may
                 # not be ready yet (this is checked by the 'finished()' method).
-                conc = self.compute_conc(corpus_obj, query, samplesize)
+                conc = self.compute_conc(corpus_obj, query, cutoff)
                 sleeptime = 0.1
                 time.sleep(sleeptime)
                 cachefile = initial_args['cachefile']
                 conc.save(cachefile, False, True)  # partial
                 os.chmod(cachefile, 0o664)
-                await cache_map.update_calc_status(corp_cache_key, query, readable=True, task_id=self._task_id)
+                await cache_map.update_calc_status(
+                    corp_cache_key, query, cutoff, readable=True, task_id=self._task_id)
                 while not conc.finished():
                     conc.save(cachefile + '.tmp', False, True)
                     await aiofiles.os.rename(cachefile + '.tmp', cachefile)
-                    sizes = await self.get_cached_conc_sizes(corpus_obj, query)
-                    await cache_map.update_calc_status(corp_cache_key, query, finished=sizes.finished,
-                                                       concsize=sizes.concsize, fullsize=sizes.fullsize,
-                                                       relconcsize=sizes.relconcsize, arf=None, task_id=self._task_id)
+                    sizes = await self.get_cached_conc_sizes(corpus_obj, query, cutoff)
+                    await cache_map.update_calc_status(
+                        corp_cache_key, query, cutoff,
+                        finished=sizes.finished,
+                        concsize=sizes.concsize,
+                        fullsize=sizes.fullsize,
+                        relconcsize=sizes.relconcsize,
+                        arf=None,
+                        task_id=self._task_id)
                     time.sleep(sleeptime)
                     sleeptime += 0.1
 
                 conc.save(cachefile + '.tmp')  # whole
                 await aiofiles.os.rename(cachefile + '.tmp', cachefile)
                 os.chmod(cachefile, 0o664)
-                sizes = await self.get_cached_conc_sizes(corpus_obj, query)
+                sizes = await self.get_cached_conc_sizes(corpus_obj, query, cutoff)
                 await cache_map.update_calc_status(
-                    corp_cache_key, query, finished=sizes.finished, concsize=conc.size(), fullsize=sizes.fullsize,
+                    corp_cache_key, query, cutoff,
+                    finished=sizes.finished,
+                    concsize=conc.size(),
+                    fullsize=sizes.fullsize,
                     relconcsize=sizes.relconcsize,
                     arf=round(conc.compute_ARF(), 2) if not corpus_obj.subcorpus_id else None,
                     task_id=self._task_id)
@@ -301,7 +328,7 @@ class ConcCalculation(GeneralWorker):
             manatee_err = extract_manatee_error(e)
             norm_err = manatee_err if manatee_err else e
             if cache_map is not None:
-                await cache_map.update_calc_status(corp_cache_key, query, finished=True, error=norm_err)
+                await cache_map.update_calc_status(corp_cache_key, query, cutoff, finished=True, error=norm_err)
 
 
 class ConcSyncCalculation(GeneralWorker):
@@ -322,24 +349,27 @@ class ConcSyncCalculation(GeneralWorker):
         self.cache_map = None
         self.conc_dir = conc_dir
 
-    async def _mark_calc_states_err(self, corp_cache_key: Optional[str], query: Tuple[str, ...], from_idx: int, err: BaseException):
+    async def _mark_calc_states_err(
+            self, corp_cache_key: Optional[str], query: Tuple[str, ...], cutoff: int, from_idx: int, err: BaseException):
         for i in range(from_idx, len(query)):
-            await self.cache_map.update_calc_status(corp_cache_key, query[:i + 1], error=err, finished=True)
+            await self.cache_map.update_calc_status(
+                corp_cache_key, query[:i + 1], cutoff, error=err, finished=True)
 
-    async def run(self,  corp_cache_key, query: Tuple[str, ...], samplesize: int):
+    async def run(self,  corp_cache_key, query: Tuple[str, ...], cutoff: int):
         self.corpus_obj = await self.corpus_factory.get_corpus(self.corpus_ident)
         setattr(self.corpus_obj, '_conc_dir', self.conc_dir)
         self.cache_map = self._cache_factory.get_mapping(self.corpus_obj)
 
         try:
             calc_from, conc = await find_cached_conc_base(
-                self.corpus_obj, corp_cache_key, query, minsize=0)
+                self.corpus_obj, query, cutoff, minsize=0)
             if isinstance(conc, InitialConc):   # we have nothing, let's start with the 1st operation only
                 for i in range(0, len(query)):
-                    await self.cache_map.add_to_map(corp_cache_key, query[:i + 1], ConcCacheStatus(task_id=self._task_id),
-                                                    overwrite=True)
-                calc_status = await self.cache_map.get_calc_status(corp_cache_key, query[:1])
-                conc = self.compute_conc(self.corpus_obj, query[:1], samplesize)
+                    await self.cache_map.add_to_map(
+                        corp_cache_key, query[:i + 1], cutoff,
+                        ConcCacheStatus(task_id=self._task_id), overwrite=True)
+                calc_status = await self.cache_map.get_calc_status(corp_cache_key, query[:1], cutoff)
+                conc = self.compute_conc(self.corpus_obj, query[:1], cutoff)
                 conc.sync()
                 conc.save(calc_status.cachefile)
                 os.chmod(calc_status.cachefile, 0o664)
@@ -350,18 +380,18 @@ class ConcSyncCalculation(GeneralWorker):
                 calc_status.recalc_relconcsize(self.corpus_obj)
                 calc_status.arf = round(
                     conc.compute_ARF(), 2) if not self.corpus_obj.subcorpus_id else None
-                await self.cache_map.add_to_map(corp_cache_key, query[:1], calc_status, overwrite=True)
+                await self.cache_map.add_to_map(corp_cache_key, query[:1], cutoff, calc_status, overwrite=True)
                 calc_from = 1
             else:
                 for i in range(calc_from, len(query)):
                     await self.cache_map.add_to_map(
-                        corp_cache_key, query[:i + 1], ConcCacheStatus(task_id=self._task_id),
+                        corp_cache_key, query[:i + 1], cutoff, ConcCacheStatus(task_id=self._task_id),
                         overwrite=True)
         except Exception as ex:
             logging.getLogger(__name__).error(ex)
             manatee_err = extract_manatee_error(ex)
             norm_err = manatee_err if manatee_err else ex
-            await self._mark_calc_states_err(corp_cache_key, query, 0, norm_err)
+            await self._mark_calc_states_err(corp_cache_key, query, cutoff, 0, norm_err)
             return
         # save additional concordance actions to cache (e.g. sample, aligned corpus without a query,...)
         for act in range(calc_from, len(query)):
@@ -370,7 +400,7 @@ class ConcSyncCalculation(GeneralWorker):
                 conc.exec_command(command, args)
                 if command in 'gae':  # user specific/volatile actions, cannot save
                     raise NotImplementedError(f'Cannot run command {command} in background')  # TODO
-                calc_status = await self.cache_map.get_calc_status(corp_cache_key, query[:act + 1])
+                calc_status = await self.cache_map.get_calc_status(corp_cache_key, query[:act + 1], cutoff)
                 conc.save(calc_status.cachefile)
                 os.chmod(calc_status.cachefile, 0o664)
                 calc_status.readable = True
@@ -380,8 +410,9 @@ class ConcSyncCalculation(GeneralWorker):
                 calc_status.recalc_relconcsize(self.corpus_obj)
                 calc_status.arf = round(
                     conc.compute_ARF(), 2) if not self.corpus_obj.subcorpus_id else None
-                await self.cache_map.add_to_map(corp_cache_key, query[:act + 1], calc_status, overwrite=True)
+                await self.cache_map.add_to_map(
+                    corp_cache_key, query[:act + 1], cutoff, calc_status, overwrite=True)
             except Exception as ex:
-                await self._mark_calc_states_err(corp_cache_key, query, act, ex)
+                await self._mark_calc_states_err(corp_cache_key, query, cutoff, act, ex)
                 logging.getLogger(__name__).error(ex)
                 return

--- a/lib/conclib/pyconc.py
+++ b/lib/conclib/pyconc.py
@@ -20,7 +20,7 @@ import logging
 import os
 import re
 from sys import stderr
-from typing import Any, Callable, Dict, List, Tuple
+from typing import Any, Dict, List, Tuple
 
 import l10n
 import manatee

--- a/lib/conclib/search.py
+++ b/lib/conclib/search.py
@@ -20,7 +20,7 @@
 
 import logging
 import os
-from typing import Callable, List, Optional, Tuple, Union
+from typing import List, Optional, Tuple, Union
 import asyncio
 
 import aiofiles.os
@@ -44,27 +44,28 @@ CONC_BG_SYNC_ALIGNED_CORP_THRESHOLD = 50000000
 CONC_BG_SYNC_SINGLE_CORP_THRESHOLD = 2000000000
 
 
-async def _get_async_conc(corp, user_id, q, corp_cache_key, samplesize, minsize) -> KConc:
+async def _get_async_conc(corp, user_id, q, corp_cache_key, cutoff, minsize) -> KConc:
     """
     """
     cache_map = plugins.runtime.CONC_CACHE.instance.get_mapping(corp)
-    status = await cache_map.get_calc_status(corp_cache_key, q)
+    status = await cache_map.get_calc_status(corp_cache_key, q, cutoff)
     if not status or status.error:
         worker = bgcalc.calc_backend_client(settings)
         ans = await worker.send_task(
             'conc_register', object.__class__,
-            (user_id, corp.portable_ident, corp_cache_key, q, samplesize, TASK_TIME_LIMIT),
+            (user_id, corp.portable_ident, corp_cache_key, q, cutoff, TASK_TIME_LIMIT),
             time_limit=CONC_REGISTER_TASK_LIMIT)
         ans.get(timeout=CONC_REGISTER_WAIT_LIMIT)
-    conc_avail = await wait_for_conc(cache_map=cache_map, corp_cache_key=corp_cache_key, q=q, minsize=minsize)
+    conc_avail = await wait_for_conc(
+        cache_map=cache_map, corp_cache_key=corp_cache_key, q=q, cutoff=cutoff, minsize=minsize)
     if conc_avail:
-        return PyConc(corp, 'l', await cache_map.readable_cache_path(corp_cache_key, q))
+        return PyConc(corp, 'l', await cache_map.readable_cache_path(corp_cache_key, q, cutoff))
     else:
-        return InitialConc(corp, await cache_map.readable_cache_path(corp_cache_key, q))
+        return InitialConc(corp, await cache_map.readable_cache_path(corp_cache_key, q, cutoff))
 
 
 async def _get_bg_conc(
-        corp: AbstractKCorpus, user_id: int, q: Tuple[str, ...], corp_cache_key: Optional[str], samplesize: int,
+        corp: AbstractKCorpus, user_id: int, q: Tuple[str, ...], corp_cache_key: Optional[str], cutoff: int,
         calc_from: int, minsize: int) -> KConc:
     """
     arguments:
@@ -72,13 +73,13 @@ async def _get_bg_conc(
     """
     cache_map = plugins.runtime.CONC_CACHE.instance.get_mapping(corp)
 
-    status = await cache_map.get_calc_status(corp_cache_key, q)
+    status = await cache_map.get_calc_status(corp_cache_key, q, cutoff)
     if status and not status.finished:  # the calc is already running, the client has to wait and check regularly
         return InitialConc(corp, status.cachefile)
     # let's create cache records of the operations we'll have to perform
     if calc_from < len(q):
         for i in range(calc_from, len(q)):
-            status = await cache_map.add_to_map(corp_cache_key, q[:i + 1], ConcCacheStatus(), overwrite=True)
+            status = await cache_map.add_to_map(corp_cache_key, q[:i + 1], cutoff, ConcCacheStatus(), overwrite=True)
             # the file cannot be valid as otherwise, calc_from would be higher
             if await aiofiles.os.path.isfile(status.cachefile):
                 await del_silent(status.cachefile)
@@ -87,16 +88,17 @@ async def _get_bg_conc(
         worker = bgcalc.calc_backend_client(settings)
         await worker.send_task(
             'conc_sync_calculate', object.__class__,
-            (user_id, corp.corpname, getattr(corp, 'subcname', None), corp_cache_key, q, samplesize),
+            (user_id, corp.corpname, getattr(corp, 'subcname', None), corp_cache_key, q, cutoff),
             time_limit=TASK_TIME_LIMIT)
     # for smaller concordances/corpora there is a chance the data
     # is ready in a few seconds - let's try this:
-    conc_avail = await wait_for_conc(cache_map=cache_map, corp_cache_key=corp_cache_key, q=q, minsize=minsize)
+    conc_avail = await wait_for_conc(
+        cache_map=cache_map, corp_cache_key=corp_cache_key, q=q, cutoff=cutoff, minsize=minsize)
     if conc_avail:
-        return PyConc(corp, 'l', await cache_map.readable_cache_path(corp_cache_key, q))
+        return PyConc(corp, 'l', await cache_map.readable_cache_path(corp_cache_key, q, cutoff))
     else:
         # return empty yet unfinished concordance to make the client watch the calculation
-        return InitialConc(corp, await cache_map.readable_cache_path(corp_cache_key, q))
+        return InitialConc(corp, await cache_map.readable_cache_path(corp_cache_key, q, cutoff))
 
 
 async def _normalize_permissions(path: str):
@@ -104,7 +106,8 @@ async def _normalize_permissions(path: str):
         os.chmod(path, 0o664)
 
 
-async def _get_sync_conc(worker, corp: AbstractKCorpus, q: Tuple[str, ...], corp_cache_key: Optional[str], samplesize: int) -> PyConc:
+async def _get_sync_conc(
+        worker, corp: AbstractKCorpus, q: Tuple[str, ...], corp_cache_key: Optional[str], cutoff: int) -> PyConc:
     """
     Calculate a concordance via a provided worker. On the Manatee side,
     wait until the concordance is complete.
@@ -112,7 +115,7 @@ async def _get_sync_conc(worker, corp: AbstractKCorpus, q: Tuple[str, ...], corp
     status = worker.create_new_calc_status()
     cache_map = plugins.runtime.CONC_CACHE.instance.get_mapping(corp)
     try:
-        conc = worker.compute_conc(corp, q, samplesize)
+        conc = worker.compute_conc(corp, q, cutoff)
         conc.sync()  # wait for the computation to finish
         status.finished = True
         status.readable = True
@@ -120,11 +123,11 @@ async def _get_sync_conc(worker, corp: AbstractKCorpus, q: Tuple[str, ...], corp
         status.fullsize = conc.fullsize()
         status.recalc_relconcsize(corp)
         status.arf = round(conc.compute_ARF(), 2) if not corp.subcorpus_id else None
-        status = await cache_map.add_to_map(corp_cache_key, q[:1], status)
+        status = await cache_map.add_to_map(corp_cache_key, q[:1], cutoff, status)
         await _normalize_permissions(status.cachefile)  # in case the file already exists
         conc.save(status.cachefile)
         await _normalize_permissions(status.cachefile)
-        await cache_map.add_to_map(corp_cache_key, q[:1], status, overwrite=True)
+        await cache_map.add_to_map(corp_cache_key, q[:1], cutoff, status, overwrite=True)
         # update size in map file
         return conc
     except Exception as e:
@@ -135,7 +138,7 @@ async def _get_sync_conc(worker, corp: AbstractKCorpus, q: Tuple[str, ...], corp
         status.finished = True
         status.concsize = 0
         status.error = manatee_err if manatee_err else e
-        status = await cache_map.add_to_map(corp_cache_key, q[:1], status, overwrite=True)
+        status = await cache_map.add_to_map(corp_cache_key, q[:1], cutoff, status, overwrite=True)
         raise status.normalized_error
 
 
@@ -153,7 +156,7 @@ async def get_conc(
         fromp: int = 0,
         pagesize: int = 0,
         asnc: int = 0,
-        samplesize: int = 0) -> KConc:
+        cutoff: int = 0) -> KConc:
     """
     Get/calculate a concordance. The function always tries to fetch as complete
     result as possible (related to the 'q' tuple) from cache. The rest is calculated
@@ -171,7 +174,7 @@ async def get_conc(
     pagesize -- a page size (in lines, related to 'fromp')
     asnc -- if 1 then KonText spawns an asynchronous process to calculate the concordance
             and will provide results as they are ready
-    samplesize -- ?
+    cutoff -- max. concordance size (if > 0 then we work only with a respective part of possible full concordance)
     """
     if not q:
         return InitialConc(corp=corp, finished=True)
@@ -189,19 +192,19 @@ async def get_conc(
         # 2nd goes through, but it already finds an open cache entry so it 'wait_for_conc()' inside the lock
         # >= 3 cannot enter but once it can the concordance is already avail. so there is no unnecessary lag here
         # (it doesn't matter whether a coroutine waits here or in 'wait_for_conc()')
-        calc_from, conc = await find_cached_conc_base(corp, corp.cache_key, q, minsize)
+        calc_from, conc = await find_cached_conc_base(corp, q, cutoff, minsize)
     if not conc and q[0][0] == 'R':  # online sample
         q_copy = list(q)
         q_copy[0] = q[0][1:]
         q_copy = tuple(q_copy)
-        await find_cached_conc_base(corp, corp.cache_key, q_copy, -1)
+        await find_cached_conc_base(corp, q_copy, cutoff, -1)
         # TODO this branch has no use (unless we want to revive online sample func)
 
     # move mid-sized aligned corpora or large non-aligned corpora to background
     if _should_be_bg_query(corp, q, asnc):
         minsize = fromp * pagesize
         conc = await _get_bg_conc(
-            corp=corp, user_id=user_id, q=q, corp_cache_key=corp.cache_key, samplesize=samplesize,
+            corp=corp, user_id=user_id, q=q, corp_cache_key=corp.cache_key, cutoff=cutoff,
             calc_from=calc_from, minsize=minsize)
     else:
         worker = GeneralWorker()
@@ -211,32 +214,32 @@ async def get_conc(
             if asnc and len(q) == 1:
                 conc = await _get_async_conc(
                     corp=corp, user_id=user_id, q=q, corp_cache_key=corp.cache_key,
-                    samplesize=samplesize, minsize=minsize)
+                    cutoff=cutoff, minsize=minsize)
 
-            # do the calc here and return (OK for small to mid sized corpora without alignments)
+            # do the calc here and return (OK for small to mid-sized corpora without alignments)
             else:
                 conc = await _get_sync_conc(
-                    worker=worker, corp=corp, q=q, corp_cache_key=corp.cache_key, samplesize=samplesize)
+                    worker=worker, corp=corp, q=q, corp_cache_key=corp.cache_key, cutoff=cutoff)
 
         # save additional concordance actions to cache (e.g. sample)
         for act in range(calc_from, len(q)):
             command, args = q[act][0], q[act][1:]
             conc.exec_command(command, args)
             cache_map = plugins.runtime.CONC_CACHE.instance.get_mapping(corp)
-            curr_status = await cache_map.get_calc_status(corp.cache_key, q[:act + 1])
+            curr_status = await cache_map.get_calc_status(corp.cache_key, q[:act + 1], cutoff)
             if curr_status and not curr_status.finished:
                 ready = await wait_for_conc(
-                    cache_map=cache_map, corp_cache_key=corp.cache_key, q=q[:act + 1], minsize=-1)
+                    cache_map=cache_map, corp_cache_key=corp.cache_key, q=q[:act + 1], cutoff=cutoff, minsize=-1)
                 if not ready:
                     raise ConcCalculationStatusException(
                         'Wait for concordance operation failed')
             elif not curr_status:
                 calc_status = worker.create_new_calc_status()
                 calc_status.concsize = conc.size()
-                calc_status = await cache_map.add_to_map(corp.cache_key, q[:act + 1], calc_status)
+                calc_status = await cache_map.add_to_map(corp.cache_key, q[:act + 1], cutoff, calc_status)
                 conc.save(calc_status.cachefile)
                 await _normalize_permissions(calc_status.cachefile)
                 # TODO can we be sure here that conc is finished even if its not the first query op.?
                 await cache_map.update_calc_status(
-                    corp.cache_key, q[:act + 1], finished=True, readable=True, concsize=conc.size())
+                    corp.cache_key, q[:act + 1], cutoff, finished=True, readable=True, concsize=conc.size())
     return conc

--- a/lib/plugin_types/conc_cache.py
+++ b/lib/plugin_types/conc_cache.py
@@ -177,19 +177,19 @@ class ConcCacheStatus:
 class AbstractConcCache(abc.ABC):
 
     @abc.abstractmethod
-    async def get_stored_size(self, corp_cache_key: str, q: QueryType) -> Union[Tuple[int, int], Tuple[None, None]]:
+    async def get_stored_size(
+            self, corp_cache_key: str, q: QueryType, cutoff: int) -> Union[Tuple[int, int], Tuple[None, None]]:
         """
         Return stored concordance size and fullsize (differs in case there is an implicit sample used).
         The method should return None if no record is found at all.
 
         Arguments:
-        corp_cache_key -- a hash generated from (sub)corpus identifier by
-                    CorpusFactory.get_corpus()
+        corp_cache_key -- a unique key/hash representing corpus(+subcorpus)
         q -- a list of query elements
         """
 
     @abc.abstractmethod
-    async def get_calc_status(self, corp_cache_key: str, query: QueryType) -> Union[ConcCacheStatus, None]:
+    async def get_calc_status(self, corp_cache_key: str, query: QueryType, cutoff: int) -> Union[ConcCacheStatus, None]:
         pass
 
     @abc.abstractmethod
@@ -201,25 +201,30 @@ class AbstractConcCache(abc.ABC):
         """
 
     @abc.abstractmethod
-    async def readable_cache_path(self, corp_cache_key: str, q: QueryType) -> Optional[str]:
+    async def readable_cache_path(self, corp_cache_key: str, q: QueryType, cutoff: int) -> Optional[str]:
         """
         Return a path to a cache file matching provided subcorpus hash and query
         elements. If there is no entry matching (corp_cache_key, q) or if a respective
         entry is not in the 'readable' state then None must be returned.
 
         arguments:
-        corp_cache_key -- hashed subcorpus identifier (corplib.CorpusFactory does this)
+        corp_cache_key -- a unique key/hash representing corpus(+subcorpus)
         q -- a list of query items
         """
 
     @abc.abstractmethod
-    async def add_to_map(self, corp_cache_key: Optional[str], query: QueryType, calc_status: ConcCacheStatus,
-                         overwrite: bool = False) -> ConcCacheStatus:
+    async def add_to_map(
+            self,
+            corp_cache_key: Optional[str],
+            query: QueryType,
+            cutoff: int,
+            calc_status: ConcCacheStatus,
+            overwrite: bool = False) -> ConcCacheStatus:
         """
         Add a cache entry. If already present, the stored version is returned unless overwrite is set to True
 
         arguments:
-        corp_cache_key -- a subcorpus identifier hash (see corplib.CorpusFactory.get_corpus)
+        corp_cache_key -- a unique key/hash representing corpus(+subcorpus)
         query -- a list/tuple of query elements
         size -- current size of a respective concordance (the one defined by corpus, corp_cache_key
                 and query)
@@ -230,28 +235,26 @@ class AbstractConcCache(abc.ABC):
         """
 
     @abc.abstractmethod
-    async def del_entry(self, corp_cache_key: Optional[str], q: QueryType):
+    async def del_entry(self, corp_cache_key: Optional[str], q: QueryType, cutoff: int):
         """
         Remove a specific entry with concrete corp_cache_key and query.
 
-        corp_cache_key -- a md5 hash generated from subcorpus identifier by
-                    CorpusFactory.get_corpus()
+        corp_cache_key -- a unique key/hash representing corpus(+subcorpus)
         q -- a list of query elements
         """
 
     @abc.abstractmethod
-    async def del_full_entry(self, corp_cache_key: Optional[str], q: QueryType):
+    async def del_full_entry(self, corp_cache_key: Optional[str], q: QueryType, cutoff: int):
         """
         Removes all the entries with the same base query no matter
         what other operations the query (e.g. shuffle, filter) contains.
 
-        corp_cache_key -- a md5 hash generated from subcorpus identifier by
-                    CorpusFactory.get_corpus()
+        corp_cache_key -- a unique key/hash representing corpus(+subcorpus)
         q -- a list of query elements
         """
 
     @abc.abstractmethod
-    async def update_calc_status(self, corp_cache_key: Optional[str], query: Tuple[str, ...], **kw):
+    async def update_calc_status(self, corp_cache_key: Optional[str], query: QueryType, cutoff: int, **kw):
         pass
 
 

--- a/lib/plugin_types/corparch/corpus.py
+++ b/lib/plugin_types/corparch/corpus.py
@@ -206,7 +206,6 @@ class CorpusInfo:
     speech_overlap_attr: Optional[str] = None
     speech_overlap_val: Optional[str] = None
     bib_struct: Optional[str] = None
-    sample_size: int = -1
     featured: bool = False
     _collator_locale: str = 'en_US'  # this does not apply for Manatee functions
     use_safe_font: bool = False

--- a/lib/plugins/default_corparch/__init__.py
+++ b/lib/plugins/default_corparch/__init__.py
@@ -470,7 +470,6 @@ class CorpusArchive(AbstractSearchableCorporaArchive):
         ans.speech_overlap_val = node.attrib.get('speech_overlap_val', None)
         ans.bib_struct = node.attrib.get('bib_struct', None)
         ans.collator_locale = node.attrib.get('collator_locale', 'en_US')
-        ans.sample_size = node.attrib.get('sample_size', -1)
         ans.use_safe_font = self._decode_bool(node.attrib.get('use_safe_font', 'false'))
 
         ref_elm = node.find('reference')

--- a/lib/plugins/default_query_suggest/backends/manatee.py
+++ b/lib/plugins/default_query_suggest/backends/manatee.py
@@ -50,7 +50,7 @@ class PosAttrPairRelManateeBackend(AbstractBackend):
             subcpath=[],
             user_id=user_id,
             pagesize=100,
-            samplesize=0,
+            cutoff=0,
             flimit=1,
             fcrit=[fcrit],
             ftt_include_empty=0,

--- a/lib/plugins/lindat_corparch2/__init__.py
+++ b/lib/plugins/lindat_corparch2/__init__.py
@@ -592,7 +592,6 @@ class CorpusArchive(AbstractSearchableCorporaArchive):
         ans.speech_overlap_val = node.attrib.get('speech_overlap_val', None)
         ans.bib_struct = node.attrib.get('bib_struct', None)
         ans.collator_locale = node.attrib.get('collator_locale', 'en_US')
-        ans.sample_size = node.attrib.get('sample_size', -1)
         ans.use_safe_font = self._decode_bool(node.attrib.get('use_safe_font', 'false'))
         ans.parallel = parallel
         ans.pmltq = pmltq

--- a/lib/plugins/tree_corparch/__init__.py
+++ b/lib/plugins/tree_corparch/__init__.py
@@ -118,8 +118,7 @@ class CorptreeParser(object):
             speech_overlap_attr=elm.attrib.get('speech_overlap_attr', None),
             speech_overlap_val=elm.attrib.get('speech_overlap_val', None),
             bib_struct=elm.attrib.get('bib_struct', None),
-            _collator_locale=elm.attrib.get('collator_locale', 'en_US'),
-            sample_size=elm.attrib.get('sample_size', -1))
+            _collator_locale=elm.attrib.get('collator_locale', 'en_US'))
 
     def parse_node(self, elm, parent: TreeNode) -> TreeNode:
         curr_parent = parent

--- a/lib/views/colls.py
+++ b/lib/views/colls.py
@@ -71,7 +71,6 @@ async def collx(amodel: ConcActionModel, req: KRequest, resp: KResponse):
         ans['save_line_limit'] = amodel.COLLS_QUICK_SAVE_MAX_LINES
         ans['text_types_data'] = await amodel.tt.export_with_norms(ret_nums=True)
         ans['quick_save_row_limit'] = amodel.COLLS_QUICK_SAVE_MAX_LINES
-        await amodel.attach_query_overview(ans)
         return ans
     except ConcNotFoundException:
         amodel.go_to_restore_conc('collx')
@@ -89,7 +88,7 @@ async def _collx(amodel: ConcActionModel, user_id: int, collpage: int, citemsper
         subcorpora_dir=amodel.subcpath,
         user_id=user_id,
         q=amodel.args.q,
-        samplesize=0,  # TODO (check also freqs)
+        cutoff=0,  # TODO (check also freqs)
         cattr=amodel.args.cattr,
         csortfn=amodel.args.csortfn,
         cbgrfns=''.join(amodel.args.cbgrfns),

--- a/lib/views/dispersion.py
+++ b/lib/views/dispersion.py
@@ -110,6 +110,5 @@ async def index(amodel: ConcActionModel, req: KRequest, response: KResponse):
         'dispersion_resolution': resolution,
         'initial_data': _get_freq_dispersion(conc, resolution),
     }
-    await amodel.attach_query_params(result)
-    await amodel.attach_query_overview(result)
+    await amodel.export_query_forms(result)
     return result

--- a/lib/views/freqs.py
+++ b/lib/views/freqs.py
@@ -199,7 +199,7 @@ async def _freqs(
         user_id=req.session_get('user', 'id'),
         q=amodel.args.q,
         pagesize=amodel.args.pagesize,
-        samplesize=0,
+        cutoff=0,
         flimit=flimit,
         fcrit=fcrit,
         freq_sort=freq_sort,
@@ -338,8 +338,7 @@ async def _freqs(
     result['ctfreq_form_args'] = CTFreqFormArgs().update(amodel.args).to_dict()
     result['text_types_data'] = await amodel.tt.export_with_norms(ret_nums=True)
     result['quick_save_row_limit'] = amodel.FREQ_QUICK_SAVE_MAX_LINES
-    await amodel.attach_query_params(result)
-    await amodel.attach_query_overview(result)
+    await amodel.export_query_forms(result)
     return result
 
 
@@ -437,7 +436,7 @@ async def _freqct(amodel: ConcActionModel, req: KRequest, resp: KResponse, max_r
     )
     ans['text_types_data'] = await amodel.tt.export_with_norms(ret_nums=True)
     ans['quick_save_row_limit'] = 0
-    await amodel.attach_query_params(ans)
+    await amodel.export_query_forms(ans)
     return ans
 
 

--- a/lib/views/options.py
+++ b/lib/views/options.py
@@ -158,8 +158,7 @@ async def viewattrsx(amodel: CorpusActionModel, req: KRequest, resp: KResponse):
         'widectx_globals': amodel.get_mapped_attrs(
             WidectxArgsMapping,
             {'structs': amodel.get_struct_opts()}
-        ),
-        'conc_args': amodel.get_curr_conc_args()
+        )
     }
 
 

--- a/public/files/js/models/concordance/common.ts
+++ b/public/files/js/models/concordance/common.ts
@@ -228,6 +228,7 @@ export interface ConcServerArgs {
     refs:Array<string>;
     fromp:number;
     q:Array<string>;
+    cutoff:number;
 }
 
 /**

--- a/public/files/js/models/concordance/summary.ts
+++ b/public/files/js/models/concordance/summary.ts
@@ -42,7 +42,7 @@ export interface ConcSummaryModelState {
     corpusIpm:number; // ipm related to the whole corpus or a named subcorpus
     ipm:number|null;
     baseCorpusSize:number;
-    corpusSampleSize:number;
+    cutoff:number;
     queryChainSize:number;
     concSize:number;
     fullSize:number; // TODO explain

--- a/public/files/js/models/freqs/regular/freqCharts.ts
+++ b/public/files/js/models/freqs/regular/freqCharts.ts
@@ -37,7 +37,7 @@ import {
     BasicFreqModuleType
 } from '../../../types/kontext';
 import { validateGzNumber } from '../../base';
-import * as copy from 'copy-to-clipboard';
+// !!! import * as copy from 'copy-to-clipboard';
 
 
 
@@ -225,7 +225,7 @@ export class FreqChartsModel extends StatelessModel<FreqChartsModelState> {
             Actions.ResultLinkCopyToClipboard,
             (state, action) => {
                 if (state.isActive) {
-                    copy(this.getShareLink(state, action.payload.sourceId));
+                    // !!! copy(this.getShareLink(state, action.payload.sourceId));
                     this.pageModel.showMessage('info', this.pageModel.translate('global__link_copied_to_clipboard'));
                 }
             }

--- a/public/files/js/models/freqs/regular/table.ts
+++ b/public/files/js/models/freqs/regular/table.ts
@@ -34,7 +34,7 @@ import { Block, FreqResultResponse } from '../common';
 import { Actions as GeneralOptsActions } from '../../options/actions';
 import { AttrItem, BasicFreqModuleType } from '../../../types/kontext';
 import { validateGzNumber } from '../../base';
-import * as copy from 'copy-to-clipboard';
+// !!! import * as copy from 'copy-to-clipboard';
 
 
 export interface FreqDataRowsModelArgs {
@@ -221,7 +221,7 @@ export class FreqDataRowsModel extends StatelessModel<FreqDataRowsModelState> {
             Actions.ResultLinkCopyToClipboard,
             (state, action) => {
                 if (state.isActive) {
-                    copy(this.getShareLink(state, action.payload.sourceId));
+                    // !!! copy(this.getShareLink(state, action.payload.sourceId));
                     this.pageModel.showMessage('info', this.pageModel.translate('global__link_copied_to_clipboard'));
                 }
             }

--- a/public/files/js/models/query/actions.ts
+++ b/public/files/js/models/query/actions.ts
@@ -455,11 +455,6 @@ export class Actions {
         name: 'QUERY_INPUT_CUTOFF_INPUT_SET'
     };
 
-    static SubmitWithCutOff: Action<{
-    }> = {
-        name: 'QUERY_INPUT_SUBMIT_WITH_CUTOFF'
-    };
-
     static SampleFormSetRlines: Action<{
         value:string;
         sampleId:string;

--- a/public/files/js/models/query/common.ts
+++ b/public/files/js/models/query/common.ts
@@ -85,7 +85,7 @@ export interface ConcQueryArgs {
     context:QueryContextArgs;
     async:boolean;
     no_query_history?:boolean;
-    sample_size?:number;
+    cutoff?:number;
     type:'concQueryArgs';
 }
 

--- a/public/files/js/models/query/first.ts
+++ b/public/files/js/models/query/first.ts
@@ -526,7 +526,7 @@ export class FirstQueryFormModel extends QueryFormModel<FirstQueryFormModelState
                     }
                 )
             }
-        )
+        );
 
         this.addActionHandler(
             Actions.QuerySubmit,
@@ -1028,7 +1028,6 @@ export class FirstQueryFormModel extends QueryFormModel<FirstQueryFormModelState
         ttSelection:TextTypes.ExportedSelection,
         noQueryHistory:boolean
     ):ConcQueryArgs {
-
         const currArgs = this.pageModel.getConcArgs();
         const args:ConcQueryArgs = {
             type: 'concQueryArgs',
@@ -1048,7 +1047,7 @@ export class FirstQueryFormModel extends QueryFormModel<FirstQueryFormModelState
             context: contextFormArgs,
             async,
             no_query_history: noQueryHistory,
-            sample_size: this.state.cutOffSize.value ?
+            cutoff: this.state.cutOffSize.value ?
                 parseInt(this.state.cutOffSize.value) :
                 undefined
         };

--- a/public/files/js/models/query/replay/common.ts
+++ b/public/files/js/models/query/replay/common.ts
@@ -111,7 +111,7 @@ export function importEncodedOperation(operation:Kontext.QueryOperation):Persist
         opid: operation.opid,
         userEntry: operation.nicearg,
         encodedArgs: operation.arg,
-        concPersistenceId: undefined,
+        concPersistenceId: operation.conc_persistence_op_id,
         size: operation.size,
         fullSize: operation.fullsize,
         formType: mapOpIdToFormType(operation.opid)

--- a/public/files/js/models/query/replay/index.ts
+++ b/public/files/js/models/query/replay/index.ts
@@ -866,6 +866,9 @@ export class QueryReplayModel extends QueryInfoModel<QueryReplayModelState> {
         opIdx:number
     ):Observable<QueryFormArgs> {
         const queryKey = this.getOpCacheKey(state, opIdx);
+        console.log('query key = ', queryKey);
+        console.log('state.operations: ', state.operations);
+        console.log('conc args cache: ', state.concArgsCache)
         return (queryKey !== undefined ?
             // cache hit
             this.queryModel.syncFrom(

--- a/public/files/js/pages/view.ts
+++ b/public/files/js/pages/view.ts
@@ -1018,10 +1018,10 @@ export class ViewPage {
                 origSubcorpName: lineViewProps.origSubCorpName,
                 providesAdHocIpm: !Dict.empty(queryFormArgs.selected_text_types),
                 baseCorpusSize: lineViewProps.concSummary.fullSize,
-                corpusSampleSize: this.layoutModel.getConf<number>('corpusSampleSize'),
                 queryChainSize: List.size(
                         this.layoutModel.getConf<Array<Kontext.QueryOperation>>(
                             'queryOverview') || []),
+                cutoff: this.layoutModel.getConcArgs().cutoff,
                 isBusy: false
             }
         );

--- a/public/files/js/types/kontext.ts
+++ b/public/files/js/types/kontext.ts
@@ -454,6 +454,11 @@ export interface QueryOperation {
      * size.
      */
      fullsize:number;
+
+     /**
+      * A persistent key of the operation
+      */
+     conc_persistence_op_id:string;
 }
 
 export type VirtualKeys = Array<Array<[string, string]>>;

--- a/public/files/js/types/viewOptions.ts
+++ b/public/files/js/types/viewOptions.ts
@@ -98,6 +98,4 @@ export interface LoadOptionsResponse extends Kontext.AjaxResponse {
 
 export interface SaveViewAttrsOptionsResponse extends Kontext.AjaxResponse {
     widectx_globals:WideCtxArgs;
-    conc_persistence_op_id:string|null;
-    conc_args:Array<[string, string]>;
 }

--- a/public/files/js/views/concordance/main/index.tsx
+++ b/public/files/js/views/concordance/main/index.tsx
@@ -308,7 +308,7 @@ export function init({
                                 {'\u00a0'}
                                 <span key="hits:4b" id="fullsize" title={String(props.fullSize)}>{he.formatNumber(props.fullSize)}</span>
                             </> :
-                            he.translate('concview__size_with_respect_to_cut_conc_{size}', {size: he.formatNumber(props.corpusSampleSize)})
+                            he.translate('concview__size_with_respect_to_cut_conc_{size}', {size: he.formatNumber(props.cutoff)})
                         }
                     </React.Fragment>
                 );

--- a/public/files/js/views/query/first/index.tsx
+++ b/public/files/js/views/query/first/index.tsx
@@ -443,15 +443,27 @@ export function init({
         };
 
         const onSubmit = () => {
-            dispatcher.dispatch<typeof Actions.QuerySubmit>({
-                name: Actions.QuerySubmit.name
-            });
+            dispatcher.dispatch(
+                Actions.QuerySubmit
+            );
+        };
+
+        const keyEventHandler = (evt) => {
+            if (evt.key === Keyboard.Value.ENTER && !evt.shiftKey) {
+                if (!evt.ctrlKey && !evt.shiftKey) {
+                    dispatcher.dispatch(
+                        Actions.QuerySubmit
+                    );
+                }
+                evt.stopPropagation();
+                evt.preventDefault();
+            }
         };
 
         return (
             <layoutViews.ModalOverlay onCloseKey={onClose}>
                 <layoutViews.CloseableFrame onCloseClick={onClose} label={he.translate('query__cutoff_heading')}>
-                    <S.CutOffBox>
+                    <S.CutOffBox onKeyDown={keyEventHandler}>
                         <div className="message">
                             <layoutViews.StatusIcon status="warning" />
                             <p>

--- a/templates/document.html
+++ b/templates/document.html
@@ -29,7 +29,6 @@ __conf.anonymousUser = {% if _anonymous %}true{% else %}false{% endif %};
 __conf.anonymousUserConcLoginPrompt = {{ anonymous_user_conc_login_prompt|to_json}};
 __conf.userFullname = {{ user_info.fullname|to_json }};
 __conf.corpusIdent = {{ corpus_ident|to_json }};
-__conf.corpusSampleSize = {{ corp_sample_size|to_json }};
 __conf.concPreflight = {{ conc_preflight|default(None, true)|to_json }};
 __conf.baseAttr = {{ base_attr|to_json }};
 __conf.currentArgs = {{ Globals|to_json }};

--- a/worker/celery.py
+++ b/worker/celery.py
@@ -81,20 +81,20 @@ class CustomTasks:
 
 @worker.task(bind=True, name='conc_register')
 @as_sync
-async def conc_register(self, user_id, corpus_ident, corp_cache_key, query, samplesize, time_limit):
-    return general.conc_register(self, user_id, corpus_ident, corp_cache_key, query, samplesize, time_limit, worker)
+async def conc_register(self, user_id, corpus_ident, corp_cache_key, query, cutoff, time_limit):
+    return general.conc_register(self, user_id, corpus_ident, corp_cache_key, query, cutoff, time_limit, worker)
 
 
 @worker.task(bind=True, name='conc_calculate')
 @as_sync
-async def conc_calculate(self, initial_args, user_id, corpus_name, subc_name, corp_cache_key, query, samplesize):
-    return general.conc_calculate(self, initial_args, user_id, corpus_name, subc_name, corp_cache_key, query, samplesize)
+async def conc_calculate(self, initial_args, user_id, corpus_name, subc_name, corp_cache_key, query, cutoff):
+    return general.conc_calculate(self, initial_args, user_id, corpus_name, subc_name, corp_cache_key, query, cutoff)
 
 
 @worker.task(bind=True, name='conc_sync_calculate')
 @as_sync
-async def conc_sync_calculate(self, user_id, corpus_name, subc_name, corp_cache_key, query, samplesize):
-    return general.conc_sync_calculate(self, user_id, corpus_name, subc_name, corp_cache_key, query, samplesize)
+async def conc_sync_calculate(self, user_id, corpus_name, subc_name, corp_cache_key, query, cutoff):
+    return general.conc_sync_calculate(self, user_id, corpus_name, subc_name, corp_cache_key, query, cutoff)
 
 
 # ----------------------------- COLLOCATIONS ----------------------------------

--- a/worker/rqworker.py
+++ b/worker/rqworker.py
@@ -58,19 +58,19 @@ class TaskWrapper:
 # ----------------------------- CONCORDANCE -----------------------------------
 
 @as_sync
-async def conc_register(user_id, corpus_ident, corp_cache_key, query, samplesize, time_limit):
+async def conc_register(user_id, corpus_ident, corp_cache_key, query, cutoff, time_limit):
     return await general.conc_register(
-        TaskWrapper(get_current_job()), user_id, corpus_ident, corp_cache_key, query, samplesize, time_limit, worker)
+        TaskWrapper(get_current_job()), user_id, corpus_ident, corp_cache_key, query, cutoff, time_limit, worker)
 
 
 @as_sync
-async def conc_calculate(initial_args, user_id, corpus_ident, corp_cache_key, query, samplesize):
-    return await general.conc_calculate(TaskWrapper(get_current_job()), initial_args, user_id, corpus_ident, corp_cache_key, query, samplesize)
+async def conc_calculate(initial_args, user_id, corpus_ident, corp_cache_key, query, cutoff):
+    return await general.conc_calculate(TaskWrapper(get_current_job()), initial_args, user_id, corpus_ident, corp_cache_key, query, cutoff)
 
 
 @as_sync
-async def conc_sync_calculate(user_id, corpus_name, subc_name, corp_cache_key, query, samplesize):
-    return await general.conc_sync_calculate(TaskWrapper(get_current_job()), user_id, corpus_name, subc_name, corp_cache_key, query, samplesize)
+async def conc_sync_calculate(user_id, corpus_name, subc_name, corp_cache_key, query, cutoff):
+    return await general.conc_sync_calculate(TaskWrapper(get_current_job()), user_id, corpus_name, subc_name, corp_cache_key, query, cutoff)
 
 
 # ----------------------------- COLLOCATIONS ----------------------------------


### PR DESCRIPTION
The value must be part of conc. cache key => whole conc_cache interface has been updated and all the related calls as well...

Also, now the whole query pipeline is loaded and some form value + query overview parts have been simplified (but it is still a mess)

We now use `cutoff` instead of confusing `samplesize` (or `sample_size`)