### PR TITLE
Fix - check also identical items in other word sections

### DIFF
--- a/public/files/js/models/concordance/actions.ts
+++ b/public/files/js/models/concordance/actions.ts
@@ -504,6 +504,10 @@ export class Actions {
         name: 'CONCORDANCE_SET_HIGHLIGHT_ITEMS'
     };
 
+    static isSetHighlightItems(a:Action):a is typeof Actions.SetHighlightItems {
+        return a.name === Actions.SetHighlightItems.name;
+    }
+
     static SetHighlightItemsDone:Action<{
         items:Array<HighlightItem>;
         matchPosAttr:string;


### PR DESCRIPTION
I had to use a kind of anti-pattern there but due to nature of kwic_connect and providers, it was likely an only option