### PR TITLE
fix regex text type query

### DIFF
--- a/lib/texttypes/model.py
+++ b/lib/texttypes/model.py
@@ -84,6 +84,8 @@ class TextTypeCollector:
                     query = f'({" | ".join(expr_items)})'
                 else:
                     query = None
+            elif type(v) is dict and 'regexp' in v:
+                query = f'{a}="{v["regexp"]}"'
             else:
                 query = f'{a}="{v}"'
 


### PR DESCRIPTION
- calendar selection inserted whole dict as regex