### PR TITLE
Rewrite internal http client lifecycle.

### DIFF
--- a/lib/action/model/base.py
+++ b/lib/action/model/base.py
@@ -15,6 +15,8 @@
 
 import hashlib
 from typing import Any, Dict, List, Optional, Tuple, Callable, Awaitable
+
+from aiohttp import ClientSession
 from sanic import Sanic
 from sanic.cookies.request import CookieRequestParameters
 
@@ -184,6 +186,10 @@ class BasePluginCtx(AbstractBasePluginCtx):
     @property
     def request(self) -> KRequest:
         return self._request
+
+    @property
+    def http_client(self) -> ClientSession:
+        return self._request.ctx.http_client
 
     @property
     def current_url(self) -> str:

--- a/lib/action/plugin/ctx/__init__.py
+++ b/lib/action/plugin/ctx/__init__.py
@@ -15,6 +15,7 @@
 import abc
 from typing import Any, Dict, Optional
 from sanic.cookies.request import CookieRequestParameters
+from aiohttp import ClientSession
 
 from action.krequest import KRequest
 from corplib import CorpusFactory
@@ -49,6 +50,11 @@ class AbstractBasePluginCtx(abc.ABC):
     @property
     @abc.abstractmethod
     def request(self) -> KRequest:
+        pass
+
+    @property
+    @abc.abstractmethod
+    def http_client(self) -> ClientSession:
         pass
 
     @property

--- a/lib/plugin_types/providers.py
+++ b/lib/plugin_types/providers.py
@@ -152,9 +152,21 @@ U = TypeVar('U', bound=AbstractProviderFrontend)
 def setup_providers(
     plg_conf: Dict[str, Any],
     db: KeyValueStorage,
-    be_type: T=AbstractProviderBackend,
-    fe_type: U=AbstractProviderFrontend,
+    be_type: type[AbstractProviderBackend],
+    fe_type: type[AbstractProviderFrontend],
 ) -> Dict[str, Tuple[T, Optional[U]]]:
+    """
+    Create instances of configured data providers and their
+    respective front-ends
+    Args:
+        plg_conf:
+        db:
+        be_type: backend type
+        fe_type: frontend type
+
+    Returns:
+
+    """
     with open(plg_conf['providers_conf'], 'rb') as fr:
         providers_conf = json.load(fr)
     providers: Dict[str, Tuple[T, Optional[U]]] = {}

--- a/lib/plugin_types/query_suggest.py
+++ b/lib/plugin_types/query_suggest.py
@@ -63,8 +63,19 @@ class AbstractBackend(abc.ABC, Generic[S]):
 
     @abc.abstractmethod
     async def find_suggestion(
-            self, user_id: int, ui_lang: str, maincorp: KCorpus, corpora: List[str], subcorpus: str,
-            value: str, value_type: str, value_subformat: str, query_type: str, p_attr: str, struct: str,
+            self,
+            plugin_ctx: PluginCtx,
+            user_id: int,
+            ui_lang: str,
+            maincorp: KCorpus,
+            corpora: List[str],
+            subcorpus: str,
+            value: str,
+            value_type: str,
+            value_subformat: str,
+            query_type: str,
+            p_attr: str,
+            struct: str,
             s_attr: str) -> S:
         """
         note: for value_subformat see PluginInterfaces.QuerySuggest.QueryValueSubformat on the client side

--- a/lib/plugin_types/token_connect.py
+++ b/lib/plugin_types/token_connect.py
@@ -47,7 +47,7 @@ import abc
 import logging
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Tuple
 
-from corplib.corpus import KCorpus
+from corplib.corpus import AbstractKCorpus
 from plugin_types.providers import (
     AbstractProviderBackend, AbstractProviderFrontend)
 
@@ -56,6 +56,7 @@ if TYPE_CHECKING:
     from action.plugin.ctx import PluginCtx
 
 from plugin_types import CorpusDependentPlugin
+from action.plugin.ctx import AbstractCorpusPluginCtx
 
 
 class BackendException(Exception):
@@ -106,8 +107,9 @@ class AbstractBackend(AbstractProviderBackend):
     @abc.abstractmethod
     async def fetch(
             self,
+            plugin_ctx: AbstractCorpusPluginCtx,
             corpora: List[str],
-            maincorp: KCorpus,
+            maincorp: AbstractKCorpus,
             token_id: int,
             num_tokens: int,
             query_args: Dict[str, str],
@@ -159,6 +161,12 @@ class AbstractFrontend(AbstractProviderFrontend):
 
 
 class AbstractTokenConnect(CorpusDependentPlugin):
+    """
+    The "token connect" plugin connects a concrete clicked token (or tokens in case user clicks on a KWIC) with
+    a data resource. Once user clicks the token, the data resource is requested to provide an information about
+    the token and the information is then showed in the "KWIC detail" box. It is possible to configure multiple
+    data resources per single token.
+    """
 
     def map_providers(self, providers: Sequence[Tuple[str, bool]]) -> Tuple[AbstractBackend, Optional[AbstractFrontend], bool]:
         """
@@ -172,7 +180,7 @@ class AbstractTokenConnect(CorpusDependentPlugin):
             self,
             plugin_ctx: 'PluginCtx',
             providers: Sequence[Tuple[str, bool]],
-            corpus: KCorpus,
+            corpus: AbstractKCorpus,
             corpora: List[str],
             token_id: int,
             num_tokens: int,
@@ -183,7 +191,7 @@ class AbstractTokenConnect(CorpusDependentPlugin):
         identified by a list of provider ids.
 
         arguments:
-        plugin_ctx -- PluginCtx object providing access to the current user request and scope
+        plugin_ctx -- PluginCtx object providing access to important runtime, "per request" resources and info
         providers -- list of defined providers we want to search in
         corpus -- corpus object used to fetch actual positional attributes used
                   to query the providers

--- a/lib/plugin_types/tokens_linking.py
+++ b/lib/plugin_types/tokens_linking.py
@@ -40,8 +40,35 @@ class AbstractTokensLinking(CorpusDependentPlugin):
             token_ranges,
             lang
     ) -> List[Dict[str, Any]]:
+        """
+        Fetch data based on clicked token ID and currelt corpora
+        Args:
+            plugin_ctx: plug-in environment providing access to key runtime "per-request" resources
+            provider_ids: providers we want to ask data for
+            corpus_id: main corpus we work with
+            token_id: clicked token ID
+            token_length: number of words in token
+            token_ranges: is a dictionary [corpus ID] -> [text start ID, text end ID]
+                So it allows for specifying context in which we evaluate the clicked token.
+                Typically, this is something like an original sentence and its translation.
+            lang: language of the UI (in case we want some messages, labels etc. from the providers)
+
+        Returns:
+            responses from each provider
+        """
         pass
 
     @abc.abstractmethod
-    async def get_required_attrs(self, plugin_ctx: PluginCtx, provider_ids, corpora, row, lang) -> List[str]:
+    async def get_required_attrs(self, plugin_ctx: PluginCtx, provider_ids: List[str], corpora: List[str]) -> List[str]:
+        """
+        Return list of positional attributes our configured providers need to be able
+        to respond. KonText uses this fetch proper attributes from a corpus when preparing requests
+        for individual providers.
+        Args:
+            plugin_ctx: plug-in environment
+            provider_ids: providers we want to ask data for
+            corpora: involved corpora (one for most corpora, two or more for aligned corpora)
+        Returns:
+
+        """
         pass

--- a/lib/plugins/common/http.py
+++ b/lib/plugins/common/http.py
@@ -87,10 +87,15 @@ class HTTPClient:
         return '&'.join(ans)
 
     async def request(
-            self, method: str, path: str, args: Union[Dict[str, Any], List[Tuple[str, Any]]], data: Any = None,
+            self,
+            client_session: aiohttp.ClientSession,
+            method: str,
+            path: str,
+            args: Union[Dict[str, Any], List[Tuple[str, Any]]],
+            data: Any = None,
             headers=None):
-        url = self._server + (path + '?' + self._process_args(args) if args else path)
-        async with aiohttp.ClientSession().request(
+        url = urllib.parse.urljoin(self._server, path + '?' + self._process_args(args) if args else path)
+        async with client_session.request(
                 method,
                 url,
                 data=data,
@@ -100,10 +105,15 @@ class HTTPClient:
             return await self.process_response(response)
 
     async def json_request(
-            self, method: str, path: str, args: Union[Dict[str, Any], List[Tuple[str, Any]]], data: Any = None,
+            self,
+            client_session: aiohttp.ClientSession,
+            method: str,
+            path: str,
+            args: Union[Dict[str, Any], List[Tuple[str, Any]]],
+            data: Any = None,
             headers=None):
         url = self._server + (path + '?' + self._process_args(args) if args else path)
-        async with aiohttp.ClientSession().request(
+        async with client_session.request(
                 method,
                 url,
                 json=data,
@@ -130,8 +140,8 @@ class HTTPApiLogin:
                 'kontext').ctx.kontext_conf.get('http_client_timeout_secs')
         return self._client_timeout
 
-    async def login(self):
-        async with aiohttp.ClientSession().request(
+    async def login(self, client_session: aiohttp.ClientSession):
+        async with client_session.request(
                 'POST',
                 self._server,
                 data=f'personal_access_token={self._api_token}',

--- a/lib/plugins/default_query_suggest/__init__.py
+++ b/lib/plugins/default_query_suggest/__init__.py
@@ -63,11 +63,13 @@ class DefaultQuerySuggest(AbstractQuerySuggest):
             if ident not in corpus_info.query_suggest.providers:
                 continue
             backend, frontend = provider
-            resp = await backend.find_suggestion(user_id=plugin_ctx.user_id, ui_lang=plugin_ctx.user_lang,
-                                                 maincorp=plugin_ctx.current_corpus, corpora=corpora,
-                                                 subcorpus=subcorpus, value=value, value_type=value_type,
-                                                 value_subformat=value_subformat, query_type=query_type,
-                                                 p_attr=p_attr, struct=struct, s_attr=s_attr)
+            resp = await backend.find_suggestion(
+                plugin_ctx=plugin_ctx,
+                user_id=plugin_ctx.user_id, ui_lang=plugin_ctx.user_lang,
+                maincorp=plugin_ctx.current_corpus, corpora=corpora,
+                subcorpus=subcorpus, value=value, value_type=value_type,
+                value_subformat=value_subformat, query_type=query_type,
+                p_attr=p_attr, struct=struct, s_attr=s_attr)
             ans.append(frontend.export_data(resp, value, plugin_ctx.user_lang).to_dict())
         return ans
 

--- a/lib/plugins/default_query_suggest/backends/__init__.py
+++ b/lib/plugins/default_query_suggest/backends/__init__.py
@@ -33,8 +33,20 @@ class HTTPBackend(AbstractBackend):
             self._client = HTTPClient('http://{}{}'.format(self._conf['server'], port_str))
 
     async def find_suggestion(
-            self, user_id, ui_lang, maincorp, corpora, subcorpus, value, value_type, value_subformat,
-            query_type, p_attr, struct, s_attr):
+            self,
+            plugin_ctx,
+            user_id,
+            ui_lang,
+            maincorp,
+            corpora,
+            subcorpus,
+            value,
+            value_type,
+            value_subformat,
+            query_type,
+            p_attr,
+            struct,
+            s_attr):
         args = dict(
             ui_lang=self._client.enc_val(ui_lang), corpora=[self._client.enc_val(c) for c in corpora])
         logging.getLogger(__name__).debug('HTTP Backend args: {0}'.format(args))

--- a/lib/plugins/default_query_suggest/backends/cnc.py
+++ b/lib/plugins/default_query_suggest/backends/cnc.py
@@ -12,8 +12,6 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 
-from typing import List
-
 import ujson as json
 from plugin_types.query_suggest import AbstractBackend
 from plugins.common.http import HTTPClient
@@ -34,12 +32,14 @@ class WordSimilarityBackend(AbstractBackend):
         else:
             self._client = HTTPClient('http://{}{}'.format(self._conf['server'], port_str))
 
-    async def find_suggestion(self, user_id, ui_lang, maincorp, corpora, subcorpus, value, value_type, value_subformat,
-                              query_type, p_attr, struct, s_attr):
+    async def find_suggestion(
+            self, plugin_ctx, user_id, ui_lang, maincorp, corpora, subcorpus, value, value_type, value_subformat,
+            query_type, p_attr, struct, s_attr):
         if p_attr == 'lemma':
             path = '/'.join([self._conf['path'], 'corpora', self._conf['corpus'], 'similarWords',
                              self._conf['model'], self._client.enc_val(value)])
-            ans, is_found = await self._client.request('GET', path, {}, None)
+            ans, is_found = await self._client.request(
+                plugin_ctx.request.ctx.http_client,'GET', path, {}, None)
             if is_found:
                 return [v['word'] for v in json.loads(ans)]
         return []

--- a/lib/plugins/default_query_suggest/backends/couch.py
+++ b/lib/plugins/default_query_suggest/backends/couch.py
@@ -58,7 +58,7 @@ class CouchDBBackend(AbstractBackend[Dict[str, CncSublemmaSuggestion]]):
         return self._db
 
     async def find_suggestion(
-            self, ui_lang, user_id, maincorp, corpora, subcorpus, value, value_type, value_subformat,
+            self, plugin_ctx, ui_lang, user_id, maincorp, corpora, subcorpus, value, value_type, value_subformat,
             query_type, p_attr, struct, s_attr) -> CncSublemmaSuggestion:
         tmp = self.db.view(self._conf['view'], start_key=norm_str(
             value), end_key=norm_str(value), include_docs=True)

--- a/lib/plugins/default_query_suggest/backends/korpusdb.py
+++ b/lib/plugins/default_query_suggest/backends/korpusdb.py
@@ -31,7 +31,7 @@ class KorpusDBBackend(AbstractBackend):
             self._client = HTTPClient('http://{}{}'.format(self._conf['server'], port_str))
 
     async def find_suggestion(
-            self, ui_lang, user_id, maincorp, corpora, subcorpus, value, value_type, value_subformat,
+            self, plugin_ctx, ui_lang, user_id, maincorp, corpora, subcorpus, value, value_type, value_subformat,
             query_type, p_attr, struct, s_attr):
         body = {
             'feats': [":form:attr:cnc:w"],

--- a/lib/plugins/default_query_suggest/backends/manatee.py
+++ b/lib/plugins/default_query_suggest/backends/manatee.py
@@ -85,7 +85,7 @@ class PosAttrPairRelManateeBackend(AbstractBackend):
         return ' | '.join(q)
 
     async def find_suggestion(
-            self, user_id, ui_lang, maincorp, corpora, subcorpus, value, value_type, value_subformat,
+            self, plugin_ctx, user_id, ui_lang, maincorp, corpora, subcorpus, value, value_type, value_subformat,
             query_type, p_attr, struct, s_attr):
         pres_corp = await self.get_preset_corp()
         used_corp = pres_corp if pres_corp is not None else maincorp

--- a/lib/plugins/default_token_connect/__init__.py
+++ b/lib/plugins/default_token_connect/__init__.py
@@ -179,7 +179,8 @@ class DefaultTokenConnect(AbstractTokenConnect):
                             f'Backend configuration problem: cookie {cname} not available')
                     cookies[cname] = plugin_ctx.cookies[cname]
                 data, status = await backend.fetch(
-                    corpora, corpus, token_id, num_tokens, args, lang, plugin_ctx.user_is_anonymous, context, cookies)
+                    plugin_ctx, corpora, corpus, token_id, num_tokens, args, lang, plugin_ctx.user_is_anonymous,
+                    context, cookies)
                 if frontend is not None:
                     ans.append(frontend.export_data(data, status, lang, is_kwic_view).to_dict())
                 else:

--- a/lib/plugins/default_token_connect/backends/__init__.py
+++ b/lib/plugins/default_token_connect/backends/__init__.py
@@ -37,7 +37,7 @@ class DisplayLinkBackend(AbstractBackend):
     def get_required_attrs(self):
         return self._conf.get('posAttrs', [])
 
-    async def fetch(self, corpora, maincorp, token_id, num_tokens, query_args, lang, is_anonymous, context=None, cookies=None):
+    async def fetch(self, plugin_ctx, corpora, maincorp, token_id, num_tokens, query_args, lang, is_anonymous, context=None, cookies=None):
         attr = self._conf['posAttrs'][0]
         value = query_args[attr]
         if value:
@@ -82,7 +82,8 @@ class HTTPBackend(AbstractBackend):
             self._client = HTTPClient('http://{}{}'.format(self._conf['server'], port_str))
 
     @cached
-    async def fetch(self, corpora, maincorp, token_id, num_tokens, query_args, lang, is_anonymous, context=None, cookies=None):
+    async def fetch(
+            self, plugin_ctx, corpora, maincorp, token_id, num_tokens, query_args, lang, is_anonymous, context=None, cookies=None):
         args = dict(
             ui_lang=self._client.enc_val(lang), corpus=self._client.enc_val(corpora[0]),
             corpus2=self._client.enc_val(corpora[1] if len(corpora) > 1 else ''),
@@ -98,4 +99,4 @@ class HTTPBackend(AbstractBackend):
         except KeyError as ex:
             raise BackendException('Failed to build query - value {0} not found'.format(ex))
 
-        return await self._client.request('GET', query_string, {})
+        return await self._client.request(plugin_ctx.http_client,'GET', query_string, {})

--- a/lib/plugins/default_token_connect/backends/cache.py
+++ b/lib/plugins/default_token_connect/backends/cache.py
@@ -52,7 +52,7 @@ def cached(fn):
     """
 
     @wraps(fn)
-    async def wrapper(self, corpora, maincorp, token_id, num_tokens, query_args, lang, is_anonymous, context, cookies):
+    async def wrapper(self, plugin_ctx, corpora, maincorp, token_id, num_tokens, query_args, lang, is_anonymous, context, cookies):
         """
         get cache db using a method defined in the abstract class
         """
@@ -63,7 +63,7 @@ def cached(fn):
         cached_data = await cache_db.get(key)
         # if no result is found in the cache, call the backend function
         if cached_data is None:
-            res = await fn(self, corpora, maincorp, token_id, num_tokens, query_args, lang, is_anonymous, context, cookies)
+            res = await fn(self, plugin_ctx, corpora, maincorp, token_id, num_tokens, query_args, lang, is_anonymous, context, cookies)
             # if a result is returned by the backend function, encode and zip its data part and store it in
             # the cache along with the "found" parameter
             await cache_db.set(key, {'data': res[0], 'found': res[1]})

--- a/lib/plugins/default_token_connect/backends/manatee.py
+++ b/lib/plugins/default_token_connect/backends/manatee.py
@@ -27,7 +27,8 @@ class ManateeWideCtxBackend(AbstractBackend):
                          'sentence', 'typeface', 'newLine', 'removeSpace']
 
     @cached
-    async def fetch(self, corpora, maincorp, token_id, num_tokens, query_args, lang, is_anonymous, context=None, cookies=None):
+    async def fetch(
+            self, plugin_ctx, corpora, maincorp, token_id, num_tokens, query_args, lang, is_anonymous, context=None, cookies=None):
         """
         display a hit in a wider context
         """
@@ -47,8 +48,9 @@ class ManateeWideCtxBackend(AbstractBackend):
         # prefer 'word' but allow other attr if word is off
         attrs = ['word'] if 'word' in p_attrs else p_attrs[0:1]
         left_ctx, right_ctx = context if context is not None else (40, 40)
-        data = conclib.get_detail_context(corp=maincorp, pos=token_id, attrs=attrs, structs=','.join(structs),
-                                          hitlen=num_tokens, detail_left_ctx=left_ctx, detail_right_ctx=right_ctx)
+        data = conclib.get_detail_context(
+            corp=maincorp, pos=token_id, attrs=attrs, structs=','.join(structs),
+            hitlen=num_tokens, detail_left_ctx=left_ctx, detail_right_ctx=right_ctx)
         if left_ctx >= int(data['maxdetail']):
             data['expand_left_args'] = None
         if right_ctx >= int(data['maxdetail']):

--- a/lib/plugins/default_token_connect/backends/treq.py
+++ b/lib/plugins/default_token_connect/backends/treq.py
@@ -48,7 +48,7 @@ class TreqBackend(HTTPBackend):
     AVAIL_LANG_MAPPINGS = None
 
     def __init__(self, conf, ident, db, ttl):
-        super(TreqBackend, self).__init__(conf, ident, db, ttl)
+        super().__init__(conf, ident, db, ttl)
         self._conf = conf
         self.AVAIL_GROUPS = conf.get('availGroups', {})
         self.AVAIL_LANG_MAPPINGS = conf.get('availTranslations', {})
@@ -110,7 +110,8 @@ class TreqBackend(HTTPBackend):
         return f'http://{self._conf["server"]}'
 
     @cached
-    async def fetch(self, corpora, maincorp, token_id, num_tokens, query_args, lang, is_anonymous, context=None, cookies=None):
+    async def fetch(
+            self, plugin_ctx, corpora, maincorp, token_id, num_tokens, query_args, lang, is_anonymous, context=None, cookies=None):
         """
         """
         primary_lang = self._lang_from_corpname(corpora[0])
@@ -138,8 +139,10 @@ class TreqBackend(HTTPBackend):
 
         else:
             data = dict(sum=0, lines=[])
-        return json.dumps(dict(treq_link=treq_link,
-                               sum=data.get('sum', 0),
-                               translations=data.get('lines', []),
-                               primary_corp=corpora[0],
-                               translat_corp=translat_corp)), True
+        return json.dumps(
+            dict(
+                treq_link=treq_link,
+                sum=data.get('sum', 0),
+                translations=data.get('lines', []),
+                primary_corp=corpora[0],
+                translat_corp=translat_corp)), True

--- a/lib/plugins/default_token_connect/backends/treq_v1.py
+++ b/lib/plugins/default_token_connect/backends/treq_v1.py
@@ -53,7 +53,7 @@ class TreqBackend(HTTPBackend):
     ANONYMOUS_SESSION_ID = None
 
     def __init__(self, conf, ident, db, ttl):
-        super(TreqBackend, self).__init__(conf, ident, db, ttl)
+        super().__init__(conf, ident, db, ttl)
         self._conf = conf
         self.BACKLINK_SERVER = conf.get('backlinkServer', conf['server'])
         self.AVAIL_GROUPS = conf.get('availGroups', {})
@@ -133,7 +133,8 @@ class TreqBackend(HTTPBackend):
         return json.loads(data)
 
     @cached
-    async def fetch(self, corpora, maincorp, token_id, num_tokens, query_args, lang, is_anonymous, context=None, cookies=None):
+    async def fetch(
+            self, plugin_ctx, corpora, maincorp, token_id, num_tokens, query_args, lang, is_anonymous, context=None, cookies=None):
         """
         """
         primary_lang = self._lang_from_corpname(corpora[0])
@@ -158,7 +159,7 @@ class TreqBackend(HTTPBackend):
                     try:
                         data = await self.make_request(path, self.ANONYMOUS_SESSION_ID)
                     except HTTPUnauthorized:
-                        self.ANONYMOUS_SESSION_ID = await self._token_api_client.login()
+                        self.ANONYMOUS_SESSION_ID = await self._token_api_client.login(plugin_ctx.http_client)
                         data = await self.make_request(path, self.ANONYMOUS_SESSION_ID)
                 else:
                     data = await self.make_request(path, cookies[self.sid_cookie])

--- a/lib/plugins/default_token_connect/mock_http_backend.py
+++ b/lib/plugins/default_token_connect/mock_http_backend.py
@@ -28,7 +28,7 @@ from plugins.default_token_connect.backends import cached
 class MockHTTPBackend(AbstractBackend):
 
     @cached
-    def fetch(self, corpora, maincorp, token_id, num_tokens, query_args, lang, context=None, cookies=None):
+    def fetch(self, plugin_ctx, corpora, maincorp, token_id, num_tokens, query_args, lang, context=None, cookies=None):
         lemma = query_args.get('lemma', None)
         word = query_args.get('word', None)
         if lemma == 'unicode':

--- a/lib/plugins/default_tokens_linking/backends/abstract.py
+++ b/lib/plugins/default_tokens_linking/backends/abstract.py
@@ -19,7 +19,7 @@
 import abc
 from typing import Any, Dict, List, Tuple
 
-from corplib import CorpusFactory
+from action.plugin.ctx import AbstractCorpusPluginCtx
 from plugin_types.providers import AbstractProviderBackend
 
 
@@ -35,7 +35,7 @@ class AbstractBackend(AbstractProviderBackend):
     @abc.abstractmethod
     async def fetch(
             self,
-            corp_factory: CorpusFactory,
+            plugin_ctx: AbstractCorpusPluginCtx,
             corpus_id: str,
             token_id: int,
             token_length: int,
@@ -47,6 +47,7 @@ class AbstractBackend(AbstractProviderBackend):
         """
 
         Args:
+            plugin_ctx:
             corp_factory:
             corpus_id: a corpus clicked token belongs to
             token_id: clicked token ID

--- a/lib/plugins/default_tokens_linking/backends/test1.py
+++ b/lib/plugins/default_tokens_linking/backends/test1.py
@@ -38,7 +38,7 @@ class Test1Backend(AbstractBackend):
 
     async def fetch(
             self,
-            corp_factory,
+            plugin_ctx,
             corpus_id,
             token_id,
             token_length,
@@ -51,7 +51,7 @@ class Test1Backend(AbstractBackend):
         tokens = {}
         clicked_word = None
         for corp_id, tok_range in token_ranges.items():
-            corp = await corp_factory.get_corpus(corp_id)
+            corp = await plugin_ctx.corpus_factory.get_corpus(corp_id)
             data = conclib.get_detail_context(
                 corp=corp, pos=tok_range[0], attrs=self.required_attrs(), structs='', hitlen=token_length,
                 detail_left_ctx=0, detail_right_ctx=tok_range[1] - tok_range[0])

--- a/lib/plugins/default_tokens_linking/backends/treq_v1.py
+++ b/lib/plugins/default_tokens_linking/backends/treq_v1.py
@@ -20,10 +20,12 @@ import logging
 import urllib
 from typing import Any, List, Tuple
 
-import conclib
+import aiohttp
 import ujson as json
 from plugins.common.http import HTTPApiLogin, HTTPClient, HTTPUnauthorized
 
+import conclib
+from action.plugin.ctx import AbstractCorpusPluginCtx
 from .abstract import AbstractBackend
 
 #
@@ -77,7 +79,7 @@ class TreqV1Backend(AbstractBackend):
 
     async def fetch(
             self,
-            corp_factory,
+            plugin_ctx,
             corpus_id,
             token_id,
             token_length,
@@ -90,7 +92,7 @@ class TreqV1Backend(AbstractBackend):
         tokens = {}
         clicked_word = None
         for corp_id, tok_range in token_ranges.items():
-            corp = await corp_factory.get_corpus(corp_id)
+            corp = await plugin_ctx.corpus_factory.get_corpus(corp_id)
             data = conclib.get_detail_context(
                 corp=corp, pos=tok_range[0], attrs=self.required_attrs(), structs='', hitlen=token_length,
                 detail_left_ctx=0, detail_right_ctx=tok_range[1] - tok_range[0])
@@ -107,7 +109,7 @@ class TreqV1Backend(AbstractBackend):
             for translat_corp in translat_corpora:
                 translat_lang = self._lang_from_corpname(translat_corp)
                 if translat_corp and translat_lang:
-                    data = await self.get_translations(
+                    data = await self._get_translations(
                         clicked_word, primary_lang, translat_lang, is_anonymous, cookies)
                     for tok_idx, token in enumerate(tokens[translat_corp]):
                         if any(token['str'] == line['righ'] for line in data['lines']):
@@ -180,12 +182,14 @@ class TreqV1Backend(AbstractBackend):
         g2 = set(self.AVAIL_GROUPS.get(lang2, []))
         return g1.intersection(g2)
 
-    async def make_request(self, path: str, session_id: str):
+    async def make_request(self, client_session: aiohttp.ClientSession ,path: str, session_id: str):
         headers = {'Cookie': f'{self.sid_cookie}={session_id}'}
-        data, valid = await self._client.request('GET', path, {}, headers=headers)
+        data, valid = await self._client.request(client_session, 'GET', path, {}, headers=headers)
         return json.loads(data)
 
-    async def get_translations(self, word: str, primary_lang: str, translat_lang: str, is_anonymous: bool, cookies):
+    async def _get_translations(
+            self, plugin_ctx: AbstractCorpusPluginCtx, word: str, primary_lang: str, translat_lang: str,
+            is_anonymous: bool, cookies):
         data = dict(sum=0, lines=[])
         common_groups = self.find_lang_common_groups(primary_lang, translat_lang)
         args = self.mk_api_args(
@@ -200,12 +204,12 @@ class TreqV1Backend(AbstractBackend):
             path = self.mk_api_path(args)
             if is_anonymous:
                 try:
-                    data = await self.make_request(path, self.ANONYMOUS_SESSION_ID)
+                    data = await self.make_request(plugin_ctx.http_client, path, self.ANONYMOUS_SESSION_ID)
                 except HTTPUnauthorized:
-                    self.ANONYMOUS_SESSION_ID = await self._token_api_client.login()
-                    data = await self.make_request(path, self.ANONYMOUS_SESSION_ID)
+                    self.ANONYMOUS_SESSION_ID = await self._token_api_client.login(plugin_ctx.http_client)
+                    data = await self.make_request(plugin_ctx.http_client, path, self.ANONYMOUS_SESSION_ID)
             else:
-                data = await self.make_request(path, cookies[self.sid_cookie])
+                data = await self.make_request(plugin_ctx.http_client, path, cookies[self.sid_cookie])
 
             max_items = self._conf.get('maxResultItems', self.DEFAULT_MAX_RESULT_LINES)
             orig = data['lines'][:max_items]

--- a/lib/plugins/default_tokens_linking/frontends/null.py
+++ b/lib/plugins/default_tokens_linking/frontends/null.py
@@ -1,0 +1,22 @@
+# Copyright (c) 2024 Charles University, Faculty of Arts,
+#                    Institute of the Czech National Corpus
+# Copyright (c) 2024 Tomas Machalek <tomas.machalek@gmail.com>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; version 2
+# dated June, 1991.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+from plugin_types.providers import AbstractProviderFrontend
+
+class NullFrontend(AbstractProviderFrontend):
+    pass

--- a/lib/views/concordance.py
+++ b/lib/views/concordance.py
@@ -349,7 +349,9 @@ async def view_conc(
             kwic_args.structs = amodel.get_struct_opts()
             kwic_args.ml_position_filters = ml_position_filters
             with plugins.runtime.TOKENS_LINKING as tl:
-                kwic_args.internal_attrs = await tl.get_required_attrs(corpus_info.tokens_linking.providers)
+                kwic_args.internal_attrs = await tl.get_required_attrs(
+                    amodel.plugin_ctx, corpus_info.tokens_linking.providers,
+                    [amodel.args.corpname] + amodel.args.align)
 
             kwic = Kwic(amodel.corp, conc)
 
@@ -519,7 +521,9 @@ async def restore_conc(amodel: ConcActionModel, req: KRequest, resp: KResponse):
             kwic_args.structs = amodel.get_struct_opts()
             corpus_info = await amodel.get_corpus_info(amodel.args.corpname)
             with plugins.runtime.TOKENS_LINKING as tl:
-                kwic_args.internal_attrs = await tl.get_required_attrs(corpus_info.tokens_linking.providers)
+                kwic_args.internal_attrs = await tl.get_required_attrs(
+                    amodel.plugin_ctx, corpus_info.tokens_linking.providers,
+                    [amodel.args.corpname] + amodel.args.align)
 
             kwic = Kwic(amodel.corp, conc)
 


### PR DESCRIPTION
Now it is a single session per each request. This means that in case a single KonText request requires to perform multiple http requests to different services (this is typical e.g. for some plug-in requests), only a single session is used for all the requests.

The ClientSession is attached to request.ctx and is initialized via Sanic request middleware and closed via Sanic response middleware.