### PR TITLE
Fix attached IDs of playback links (support ticket 2933)

### DIFF
--- a/public/files/js/models/concordance/actions.ts
+++ b/public/files/js/models/concordance/actions.ts
@@ -80,7 +80,7 @@ export class Actions {
     };
 
     static PlayAudioSegment:Action<{
-        chunksIds:Array<number>;
+        linkIds:Array<string>;
     }> = {
         name: 'CONCORDANCE_PLAY_AUDIO_SEGMENT'
     };

--- a/public/files/js/models/concordance/common.ts
+++ b/public/files/js/models/concordance/common.ts
@@ -101,17 +101,25 @@ export enum PosAttrRole {
     INTERNAL = 0b10,
 }
 
-export class TextChunk {
+export interface TextChunk {
     className:string;
     token:Token;
-    openLink:{speechPath:string};
-    closeLink:{speechPath:string};
+    openLink:{speechPath:string, linkId: string};
+    closeLink:{speechPath:string, linkId: string};
     continued:boolean;
     showAudioPlayer:boolean;
     posAttrs:Array<string>; // array => multiple pos attrs per whole 'pseudo-position'
     displayPosAttrs:Array<string>;
     description?:Array<string>;
 }
+
+
+export function textChunkMatchesLinkId(tch:TextChunk, linkId:string) {
+    return tch.openLink && tch.openLink.linkId === linkId ||
+        tch.closeLink && tch.closeLink.linkId === linkId;
+}
+
+
 
 export interface Line {
     lineGroup:number|undefined;

--- a/public/files/js/models/concordance/line.ts
+++ b/public/files/js/models/concordance/line.ts
@@ -19,7 +19,7 @@
  */
 
 import { List, pipe } from 'cnc-tskit';
-import { KWICSection, MLPositionsData, TextChunk } from './common';
+import { KWICSection, MLPositionsData, TextChunk, textChunkMatchesLinkId } from './common';
 
 
 export class ConclineSectionOps {
@@ -57,7 +57,7 @@ export class ConclineSectionOps {
         return sect.left.concat(sect.kwic, sect.right);
     }
 
-    static findChunk(sect:KWICSection, tokenId:number):TextChunk {
-        return List.find(v => v.token.id === tokenId, ConclineSectionOps.getAllChunks(sect));
+    static findChunk(sect:KWICSection, linkId:string):TextChunk {
+        return List.find(v => textChunkMatchesLinkId(v, linkId), ConclineSectionOps.getAllChunks(sect));
     }
 }

--- a/public/files/js/views/concordance/lineExtras/index.tsx
+++ b/public/files/js/views/concordance/lineExtras/index.tsx
@@ -89,7 +89,10 @@ export function init(dispatcher:IActionDispatcher, he:Kontext.ComponentHelpers, 
             dispatcher.dispatch<typeof Actions.PlayAudioSegment>({
                 name: Actions.PlayAudioSegment.name,
                 payload: {
-                    chunksIds: props.chunks.map(v => v.token.id)
+                    linkIds: List.map(
+                        x => x.openLink ? x.openLink.linkId : x.closeLink.linkId,
+                        props.chunks
+                    )
                 }
             });
         };


### PR DESCRIPTION
The broken method relied borrowing IDs from tokens which was unreliable (e.g. non-unique values) and too convoluted