### PR TITLE
Couple of fixes/improvements in freq calculation:

### DIFF
--- a/lib/bgcalc/freqs/__init__.py
+++ b/lib/bgcalc/freqs/__init__.py
@@ -240,6 +240,11 @@ async def calculate_freqs(args: FreqCalcArgs):
         elif isinstance(tmp_result, Exception):
             raise tmp_result
         calc_result = tmp_result
+        if not calc_result.contains_direct_data():
+            calc_result, _ = find_cached_result(args)
+            if calc_result is None:
+                raise BgCalcError('Failed to get expected freqs result')
+
     lastpage = None
     fstart = (args.fpage - 1) * args.fmaxitems
     ans = []

--- a/lib/bgcalc/freqs/types.py
+++ b/lib/bgcalc/freqs/types.py
@@ -43,9 +43,23 @@ class FreqCalcArgs:
 
 @dataclass
 class FreqCalcResult:
-    freqs: List[FreqData]
-    conc_size: int
+    """
+    FreqCalcResult provides frequency distribution data based
+    on multiple criteria where each criterion has its own
+    entry in the `freqs` attribute.
+    Note: we've stopped using multi-block data but to avoid rewriting
+    the types we still keep the structure.
 
+    The class is designed to provide the data either directly (`freqs` property)
+    or indirectly (`DataPath`) when passing information about
+    larger results (e.g. between worker and web server)
+    """
+    conc_size: int
+    freqs: Optional[List[FreqData]]
+    data_path: Optional[str] = None  # data_path and freqs should be mutually exclusive
+
+    def contains_direct_data(self):
+        return self.freqs is not None
 
 @dataclass
 class Freq2DCalcArgs:

--- a/lib/conclib/freq.py
+++ b/lib/conclib/freq.py
@@ -33,10 +33,10 @@ class FreqItem:
 @dataclass
 class FreqData:
     Head: List[Dict[str, Any]]
-    Items: List[FreqItem]
     Size: int   # we need this as Items contain only the current page
     SkippedEmpty: bool
     NoRelSorting: bool
+    Items: List[FreqItem]
 
 
 @dataclass

--- a/lib/views/freqs.py
+++ b/lib/views/freqs.py
@@ -204,7 +204,7 @@ async def _freqs(
         cutoff=0,
         flimit=flimit,
         fcrit=fcrit,
-        freq_sort=freq_sort,
+        freq_sort=freq_sort if freq_sort else 'freq',  # making sure it is always set for consistent caching
         rel_mode=rel_mode,
         collator_locale=corp_info.collator_locale,
         fmaxitems=amodel.args.fmaxitems,


### PR DESCRIPTION
1) ineffective iteration through lines (once last line has been fetched,
   there is no reason to continue)
2) first line calc. based on pagination - fixed formula 3) do not pass whole data (if too large) between worker and webserver,
   just pass a respective data path