### PR TITLE
Support for custom attr delimiter

### DIFF
--- a/dockerfiles/Dockerfile.kontext-cypress-jammy
+++ b/dockerfiles/Dockerfile.kontext-cypress-jammy
@@ -1,4 +1,4 @@
-FROM czcorpus/kontext-manatee:2.223.6-jammy
+FROM czcorpus/kontext-manatee:2.225.8-jammy
 
 SHELL ["/bin/bash", "--login", "-c"]
 

--- a/dockerfiles/Dockerfile.kontext-dev-jammy
+++ b/dockerfiles/Dockerfile.kontext-dev-jammy
@@ -1,4 +1,4 @@
-FROM czcorpus/kontext-manatee:2.223.6-jammy
+FROM czcorpus/kontext-manatee:2.225.8-jammy
 
 SHELL ["/bin/bash", "--login", "-c"]
 

--- a/dockerfiles/Dockerfile.kontext-jammy
+++ b/dockerfiles/Dockerfile.kontext-jammy
@@ -1,4 +1,4 @@
-FROM czcorpus/kontext-manatee:2.223.6-jammy
+FROM czcorpus/kontext-manatee:2.225.8-jammy
 
 SHELL ["/bin/bash", "--login", "-c"]
 COPY . .

--- a/dockerfiles/Dockerfile.manatee-jammy
+++ b/dockerfiles/Dockerfile.manatee-jammy
@@ -1,4 +1,4 @@
-# This dockerfile produces the image czcorpus/kontext-manatee:2.223.6-jammy
+# This dockerfile produces the image czcorpus/kontext-manatee:2.225.8-jammy
 FROM ubuntu:jammy
 SHELL ["/bin/bash", "--login", "-c"]
 WORKDIR /opt/kontext
@@ -6,8 +6,8 @@ COPY ./scripts/install/steps.py ./scripts/install/*.patch ./scripts/install/
 
 RUN apt-get update && apt-get install -y git autoconf-archive swig libpcre++ locales python3 python3-dev wget build-essential libltdl-dev libpcre3-dev bison \
   && sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && dpkg-reconfigure --frontend=noninteractive locales \
-  && python3 scripts/install/steps.py SetupManatee --ucnk --step-args 2.223.6 scripts/install/ucnk-manatee-2.223.6.patch 0 \
-  && rm -r /usr/local/src/manatee-open-2.223.6 \
+  && python3 scripts/install/steps.py SetupManatee --ucnk --step-args 2.225.8 0 \
+  && rm -r /usr/local/src/manatee-open-2.225.8 \
   && apt-get -y remove python3-dev build-essential libltdl-dev libpcre3-dev ocaml-base-nox git autoconf-archive bison \
     # for some reason, the installation of Manatee produces incorrect target path /usr/local/local/lib/...
   && if [[ -d /usr/local/local/lib/python3.10/dist-packages ]]; then mv /usr/local/local/lib/python3.10/dist-packages/* /usr/local/lib/python3.10/dist-packages/; fi \

--- a/dockerfiles/Dockerfile.rqworker-jammy
+++ b/dockerfiles/Dockerfile.rqworker-jammy
@@ -1,4 +1,4 @@
-FROM czcorpus/kontext-manatee:2.223.6-jammy
+FROM czcorpus/kontext-manatee:2.225.8-jammy
 
 WORKDIR /opt/kontext
 COPY . .

--- a/lib/kwiclib/__init__.py
+++ b/lib/kwiclib/__init__.py
@@ -477,10 +477,10 @@ class Kwic:
         ans = []
         for item in tokens:
             if item.get('class') == 'attr':
-                # TODO configurable delimiter
+                # there is always one leading `attr_delimiter`
+                attr_delimiter = item['str'][0]
                 # a list is used for future compatibility
-                # there is always one leading /, first split item is empty and excessive
-                prev['posattrs'] = item['str'].split('/')[1:]
+                prev['posattrs'] = item['str'][1:].split(attr_delimiter)
             else:
                 ans.append(item)
             prev = item

--- a/lib/settings.py
+++ b/lib/settings.py
@@ -20,7 +20,7 @@ provides some additional helper methods.
 """
 
 import os
-from typing import Any, DefaultDict, Dict, Optional, Union
+from typing import Any, DefaultDict, Dict, Union
 
 import ujson as json
 from lxml import etree

--- a/lib/views/concordance.py
+++ b/lib/views/concordance.py
@@ -124,10 +124,12 @@ async def query(amodel: ConcActionModel, req: KRequest, resp: KResponse):
     await amodel.export_subcorpora_list(out)
     resp.set_result(out)
 
+
 @bp.route('/query_submit', methods=['POST'])
 @http_action(
     mutates_result=True,
-    action_log_mapper=log_mapping.mk_query_submit(settings.get_bool('logging', 'log_queries', False)),
+    action_log_mapper=log_mapping.mk_query_submit(
+        settings.get_bool('logging', 'log_queries', False)),
     return_type='json',
     action_model=ConcActionModel)
 async def query_submit(amodel: ConcActionModel, req: KRequest, resp: KResponse):
@@ -601,6 +603,7 @@ async def normalize_conc_form_args_arch(amodel: ConcActionModel, req: KRequest, 
     logging.getLogger(__name__).debug('normalizing query chain {}, with author_id {}'.format(
         ' -> '.join(chain), author_id))
     return dict(author_id=author_id)
+
 
 @bp.route('/permanent_link', ['POST'])
 @http_action(return_type='json', action_model=ConcActionModel)

--- a/scripts/install/install.py
+++ b/scripts/install/install.py
@@ -26,7 +26,7 @@ import subprocess
 KONTEXT_PATH = os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), '../..'))
 KONTEXT_INSTALL_CONF = os.environ.get('KONTEXT_INSTALL_CONF', 'config.default.xml')
 SCHEDULER_INSTALL_CONF = os.environ.get('SCHEDULER_INSTALL_CONF', 'rq-schedule-conf.sample.json')
-MANATEE_VER = '2.223.6'
+MANATEE_VER = '2.225.8'
 
 REQUIREMENTS = [
     'python3-pip',
@@ -60,7 +60,7 @@ REQUIREMENTS = [
 if __name__ == "__main__":
     argparser = argparse.ArgumentParser('Kontext instalation script')
     argparser.add_argument('--ucnk', action='store_true', default=False, help='Use UCNK sources')
-    argparser.add_argument('--patch', dest='patch_path', action='store',
+    argparser.add_argument('--patch', dest='patch_paths', action='append',
                            default=None, help='Path to UCNK Manatee patch')
     argparser.add_argument('--manatee-version', dest='manatee_version',
                            action='store', default=MANATEE_VER, help='Set Manatee version')
@@ -99,7 +99,7 @@ if __name__ == "__main__":
     steps.SetupBgCalc(KONTEXT_PATH, stdout, stderr).run()
     steps.SetupNginx(KONTEXT_PATH, stdout, stderr).run()
     steps.SetupManatee(KONTEXT_PATH, stdout, stderr, args.no_cert_check).run(
-        args.manatee_version, args.patch_path, ucnk_manatee=args.ucnk)
+        args.manatee_version, args.patch_paths, ucnk_manatee=args.ucnk)
     steps.SetupKontext(
         kontext_path=KONTEXT_PATH, kontext_conf=KONTEXT_INSTALL_CONF,
         scheduler_conf=SCHEDULER_INSTALL_CONF,  stdout=stdout, stderr=stderr).run()

--- a/scripts/install/steps.py
+++ b/scripts/install/steps.py
@@ -167,7 +167,7 @@ class SetupManatee(InstallationStep):
     def abort(self):
         pass
 
-    def run(self, manatee_version: str, patch_path: str = None, make_symlinks: bool = True, ucnk_manatee: bool = False):
+    def run(self, manatee_version: str, patch_paths: List[str], make_symlinks: bool = True, ucnk_manatee: bool = False):
         # install manatee with ucnk patch
         print('Installing Manatee-Open...')
         src_working_dir = f'/usr/local/src/manatee-open-{manatee_version}'
@@ -197,7 +197,7 @@ class SetupManatee(InstallationStep):
             subprocess.check_call(
                 ['tar', 'xzvf', f'manatee-open-{manatee_version}.tar.gz'], cwd='/usr/local/src', stdout=self.stdout)
 
-            if patch_path is not None:
+            for patch_path in patch_paths:
                 if os.path.isfile(os.path.join(self.kontext_path, patch_path)):
                     subprocess.check_call(['cp', os.path.join(self.kontext_path, patch_path), './'],
                                           cwd=src_working_dir, stdout=self.stdout)
@@ -365,7 +365,7 @@ if __name__ == '__main__':
         obj.run()
     elif args.step_name == 'SetupManatee':
         obj = SetupManatee(*init_step_args, True)
-        obj.run(args.step_args[0], args.step_args[1], bool(int(args.step_args[2])), args.ucnk)
+        obj.run(args.step_args[0], args.step_args[1:-1], bool(int(args.step_args[-1])), args.ucnk)
     else:
         raise Exception(f'Unknown action: {args.step_name}')
 

--- a/scripts/install/ucnk-manatee-2.223.6-delim.patch
+++ b/scripts/install/ucnk-manatee-2.223.6-delim.patch
@@ -1,0 +1,11 @@
+--- concord/concget.cc  2024-08-15 14:49:19.219393444 +0200
++++ concord/concget.cc  2024-08-15 14:07:02.292370448 +0200
+@@ -326,7 +326,7 @@
+
+ void get_corp_text (PAvec &attrs, string currtags, Position fpos, Position tpos,
+                     vector<string> &strs, vector<string> &tags,
+-                    char posdelim = ' ', char attrdelim = '/')
++                    char posdelim = ' ', char attrdelim = '\x1F')
+ {
+     if (fpos >= tpos || attrs.empty()) return;
+     TextIterator *wordi = attrs[0]->textat (fpos);


### PR DESCRIPTION
- get delimiter directly from data (first character of attr string)
- include manatee patch to set `attrdelim` as `\x1F`
- support passing list of patches in install script
- update manatee version to `2.225.8`