### PR TITLE
Fix - archive() method:

### DIFF
--- a/lib/plugin_types/query_persistence/__init__.py
+++ b/lib/plugin_types/query_persistence/__init__.py
@@ -137,6 +137,10 @@ class AbstractQueryPersistence(abc.ABC):
         2) It is expected the concordance parameters are available via
         key-value (Redis) storage already (this should be ensured by KonText)
 
+        3) In case the query to be archived contains a reference to a previous
+        query (e.g. from a filter query to the initial search), it must be archived
+        too up until the first/initial query.
+
         arguments:
         conc_id -- an identifier of the concordance
 

--- a/lib/plugins/mysql_query_persistence/__init__.py
+++ b/lib/plugins/mysql_query_persistence/__init__.py
@@ -191,29 +191,33 @@ class MySqlQueryPersistence(AbstractQueryPersistence):
         return latest_id
 
     async def archive(self, conc_id, explicit):
-        data_key = conc_id
+        curr_conc_id = conc_id
         hard_limit = 100
+        i = 0
+        first_data = None
         async with self._archive.connection() as conn:
-            while data_key is not None and hard_limit > 0:  # hard_limit prevents ending up in infinite loops of 'prev_id'
-                data = await self.db.get(mk_key(conc_id))
+            while curr_conc_id is not None and i < hard_limit:  # hard_limit prevents ending up in infinite loops of 'prev_id'
+                data = await self.db.get(mk_key(curr_conc_id))
+                if i == 0:
+                    first_data = data
                 if data:
                     async with await conn.cursor() as cursor:
                         try:
                             await cursor.execute(
                                 "INSERT INTO kontext_conc_persistence (id, data, created, last_access) VALUES (%s, %s, NOW(), NULL)",
-                                (data_key, json.dumps(data)))
+                                (curr_conc_id, json.dumps(data)))
                         except IntegrityError as err:
-                            logging.getLogger(__name__).warning(f'failed to archive {data_key}: {err} (ignored)')
+                            logging.getLogger(__name__).warning(f'failed to archive {curr_conc_id}: {err} (ignored)')
                             pass  # key already in db
                 else:
                     async with await conn.cursor() as cursor:
-                        await cursor.execute('SELECT id FROM kontext_conc_persistence WHERE id = %s LIMIT 1', (data_key,))
+                        await cursor.execute('SELECT id FROM kontext_conc_persistence WHERE id = %s LIMIT 1', (curr_conc_id,))
                         r = await cursor.fetchone()
                         if r is None:
-                            raise QueryPersistenceRecNotFound(f'record {data_key} not found neither in cache nor in archive')
-                data_key = data.get('prev_id', None)
-                hard_limit -= 1
-
+                            raise QueryPersistenceRecNotFound(f'record {curr_conc_id} not found neither in cache nor in archive')
+                curr_conc_id = data.get('prev_id', None)
+                i += 1
+        return first_data
 
     async def clear_old_archive_records(self):
         now = datetime.datetime.now()

--- a/lib/plugins/ucnk_query_persistence/__init__.py
+++ b/lib/plugins/ucnk_query_persistence/__init__.py
@@ -79,6 +79,7 @@ class UCNKQueryPersistence(MySqlQueryPersistence):
 
     async def archive(self, conc_id, explicit):
         await self.db.list_append(self._archive_queue_key, dict(key=conc_id, explicit=explicit))
+        return await self.db.get(mk_key(conc_id))
 
     def export_tasks(self):
         return tuple()

--- a/lib/views/concordance.py
+++ b/lib/views/concordance.py
@@ -536,10 +536,10 @@ async def restore_conc(amodel: ConcActionModel, req: KRequest, resp: KResponse):
 @http_action(access_level=2, return_type='json', action_model=UserActionModel)
 async def save_query(amodel: UserActionModel, req: KRequest, resp: KResponse):
     with plugins.runtime.QUERY_HISTORY as qh, plugins.runtime.QUERY_PERSISTENCE as qp:
-        _, data = await qp.archive(req.json['query_id'], True)
+        data = await qp.archive(req.json['query_id'], True)
         if qp.stored_form_type(data) == 'pquery':
             for conc_id in data.get('form', {}).get('conc_ids', []):
-                cn, _ = await qp.archive(conc_id, True)
+                await qp.archive(conc_id, True)
 
         hsave = await qh.make_persistent(
             amodel.session_get('user', 'id'),

--- a/public/files/js/views/searchHistory/full/index.tsx
+++ b/public/files/js/views/searchHistory/full/index.tsx
@@ -658,9 +658,12 @@ export function init(
                     </span>
                 </div>
                 {renderQuery()}
-                <DataRowActions toolbarVisible={toolbarVisible}
-                        nameEditorVisible={nameEditorVisible}
-                        data={data} />
+                {data.q_supertype !== 'conc' || data.form_type !== 'filter' ?
+                    <DataRowActions toolbarVisible={toolbarVisible}
+                            nameEditorVisible={nameEditorVisible}
+                            data={data} /> :
+                    null
+                }
             </S.DataRowLi>
         );
     };


### PR DESCRIPTION
1) incorrect iteration using prev_id (luckily, we request archiving for
   each query chain item individually so this has had no effect)
2) incorrect returned type accross different implementations of
   archive()
3) we cannot save filter queries as if it were normal query - so this has
   been disabled in GUI