### PR TITLE
Misc fixes in extended query history:

### DIFF
--- a/public/files/js/models/searchHistory/index.ts
+++ b/public/files/js/models/searchHistory/index.ts
@@ -506,7 +506,8 @@ export class SearchHistoryModel extends StatefulModel<SearchHistoryModelState> {
                         args.fsStructattrName = this.state.fsStructattrName;
                         args.fsStructattrValue = this.state.fsStructattrValue;
                         args.fsStructureName = this.state.fsStructureName;
-        
+                        args.fsSubcorpus = this.state.fsSubcorpus;
+
                     } else {
                         args.fsAnyPropertyValue = this.state.fsAnyPropertyValue;
                     }
@@ -518,7 +519,7 @@ export class SearchHistoryModel extends StatefulModel<SearchHistoryModelState> {
                         args.fsWlattr = this.state.fsWlAttr;
                         args.fsWlPfilter = this.state.fsWlPFilter;
                         args.fsWlNfilter = this.state.fsWlNFilter;
-        
+
                     } else {
                         args.fsAnyPropertyValue = this.state.fsAnyPropertyValue;
                     }


### PR DESCRIPTION
1) escape url query for Bleve
2) combine _all:... with concrete atributes to achieve stuff like
   "search in any field but only in syn2020"
3) fix sql backend method to handle empty result