### PR TITLE
UX tweak - to make clearer values of posattrs and structattrs don't

### DIFF
--- a/public/files/js/views/searchHistory/full/forms.tsx
+++ b/public/files/js/views/searchHistory/full/forms.tsx
@@ -127,9 +127,11 @@ export function init(
                 {'\u00a0'}
                 <input type="text" value={props.attr} onChange={handleAttrChange} />
                 {'\u00a0'}
+                <span className="optional">(</span>
                 {he.translate('qhistory__used_property_value')}
                 {'\u00a0'}
                 <input type="text" value={props.value} onChange={handleValueChange} />
+                <span className="optional">)</span>
             </div>
         );
     };
@@ -189,9 +191,11 @@ export function init(
                 {'\u00a0'}
                 <input type="text" value={props.attr} onChange={handleAttrChange} />
                 {'\u00a0'}
+                <span className="optional">(</span>
                 {he.translate('qhistory__used_property_value')}
                 {'\u00a0'}
                 <input type="text" value={props.value} onChange={handleValueChange} />
+                <span className="optional">)</span>
             </div>
 
         );

--- a/public/files/js/views/searchHistory/full/style.tsx
+++ b/public/files/js/views/searchHistory/full/style.tsx
@@ -369,5 +369,8 @@ export const FulltextFieldset = styled.fieldset`
         align-items: center;
         padding: 0.3em 0;
 
+        .optional {
+            font-size: 1.6em;
+        }
     }
 `;


### PR DESCRIPTION
have to be filled