### PR TITLE
Fix - exclamation mark is a non-spec character in CQL...

### DIFF
--- a/scripts/build/cql.pegjs
+++ b/scripts/build/cql.pegjs
@@ -242,7 +242,7 @@ PQuery =
 // ------------------------------- tokens -------------------------------
 
 RG_NON_LETTER = '\''
-RG_NON_SPEC = [#%§]
+RG_NON_SPEC = [#%§!]
 RG_AMP = '&'
 
 LETTER_PHON =


### PR DESCRIPTION
... except for some special cases (regexp look(ahead|behind)).

Support ticket 2962