### PR TITLE
Configurable task delete_old_records - new arg. num_del_per_run ...

### DIFF
--- a/lib/plugins/ucnk_query_history/__init__.py
+++ b/lib/plugins/ucnk_query_history/__init__.py
@@ -113,7 +113,7 @@ class UcnkQueryHistory(MySqlQueryHistory):
         await self._delete_indexed_item(plugin_ctx, query_id, user_id, created)
         return done
 
-    async def delete_old_records(self):
+    async def delete_old_records(self, num_del_per_run=None):
         """
         Preserve only preserve_amount of newest records.
         Named records are kept intact.
@@ -123,6 +123,7 @@ class UcnkQueryHistory(MySqlQueryHistory):
             async with await conn.cursor(dictionary=True) as cursor:
                 await self._db.begin_tx(cursor)
                 try:
+                    num_del = num_del_per_run if num_del_per_run is not None else self._del_chunk_size
                     await cursor.execute(
                         f'''
                         SELECT user_id, created, query_id
@@ -136,7 +137,7 @@ class UcnkQueryHistory(MySqlQueryHistory):
                         ORDER BY created
                         LIMIT %s
                         ''',
-                        (self.preserve_amount, self._del_chunk_size)
+                        (self.preserve_amount, num_del)
                     )
                     for row in await cursor.fetchall():
                         await cursor.execute(


### PR DESCRIPTION
... as it highly affects performance and we need to be able to tune the value easily without changing config.xml and restarting Rq worker