### PR TITLE
Workaround prototype for saving parallel concordances

### DIFF
--- a/lib/action/argmapping/action.py
+++ b/lib/action/argmapping/action.py
@@ -14,7 +14,7 @@
 # GNU General Public License for more details.
 
 
-from dataclasses import fields
+from dataclasses import fields, MISSING
 from typing import List, NewType, Optional, Type, TypeVar
 
 from action.errors import UserReadableException
@@ -26,6 +26,12 @@ StrOpt = NewType('StrOpt', Optional[str])
 ListStrOpt = NewType('ListStrOpt', List[str])
 IntOpt = NewType('IntOpt', Optional[int])
 ListIntOpt = NewType('ListIntOpt', List[int])
+
+
+def is_optional_field(field_obj):
+    has_default = field_obj.default is not MISSING
+    has_default_factory = field_obj.default_factory is not MISSING
+    return has_default or has_default_factory
 
 
 def create_mapped_args(tp: Type, req: Request):
@@ -43,6 +49,8 @@ def create_mapped_args(tp: Type, req: Request):
             v = req.form.get(mk, [])
         if mtype == str:
             if len(v) == 0:
+                if is_optional_field(field):
+                    continue
                 raise UserReadableException(f'Missing request argument {mk}')
             if len(v) > 1:
                 raise UserReadableException(f'Argument {mk} is cannot be multi-valued')
@@ -54,6 +62,8 @@ def create_mapped_args(tp: Type, req: Request):
                 data[mk] = v[0]
         elif mtype == List[str]:
             if len(v) == 0:
+                if is_optional_field(field):
+                    continue
                 raise UserReadableException(f'Missing request argument {mk}')
             data[mk] = v
         elif mtype == ListStrOpt:
@@ -61,6 +71,8 @@ def create_mapped_args(tp: Type, req: Request):
                 data[mk] = v
         elif mtype == int:
             if len(v) == 0:
+                if is_optional_field(field):
+                    continue
                 raise UserReadableException(f'Missing request argument {mk}')
             elif len(v) > 1:
                 raise UserReadableException(f'Argument {mk} is cannot be multi-valued')
@@ -72,6 +84,8 @@ def create_mapped_args(tp: Type, req: Request):
                 data[mk] = int(v[0])
         elif mtype == List[int]:
             if len(v) == 0:
+                if is_optional_field(field):
+                    continue
                 raise UserReadableException(f'Missing request argument {mk}')
             data[mk] = [int(x) for x in v]
         elif mtype == ListIntOpt:

--- a/lib/plugins/export/default_csv.py
+++ b/lib/plugins/export/default_csv.py
@@ -129,7 +129,7 @@ class CSVExport(AbstractExport):
             if 'Align' in line:
                 lang_rows += self._process_lang(
                     line['Align'], left_key, kwic_key, right_key, False, amodel.args.attr_vmode, data.merged_attrs, data.merged_ctxattrs)
-            self._writerow(row_num if args.numbering else None, *lang_rows)
+            self._writerow(row_num + args.numbering_offset if args.numbering else None, *lang_rows)
 
     async def write_coll(self, amodel: ConcActionModel, data: CalculateCollsResult, args: SavecollArgs):
         if args.colheaders or args.heading:

--- a/lib/plugins/export/default_txt.py
+++ b/lib/plugins/export/default_txt.py
@@ -71,6 +71,7 @@ class TXTExport(AbstractExport):
         output['to_line'] = min(args.to_line, data.concsize)
         output['heading'] = args.heading
         output['numbering'] = args.numbering
+        output['numbering_offset'] = args.numbering_offset
         output['align_kwic'] = args.align_kwic
         output['human_corpname'] = amodel.corp.human_readable_corpname
         output['usesubcorp'] = amodel.args.usesubcorp
@@ -89,7 +90,7 @@ class TXTExport(AbstractExport):
         amodel.update_output_with_group_info(output)
 
         template = self._template_env.get_template('txt_conc.jinja2')
-        self._data = await template.render_async(output)
+        self._data += await template.render_async(output)
 
     async def write_coll(self, amodel: ConcActionModel, data: CalculateCollsResult, args: SavecollArgs):
         output = asdict(data)

--- a/lib/plugins/export/default_xlsx.py
+++ b/lib/plugins/export/default_xlsx.py
@@ -156,7 +156,7 @@ class XLSXExport(AbstractExport):
             if 'Align' in line:
                 lang_rows += self._process_lang(
                     line['Align'], left_key, kwic_key, right_key, False, amodel.args.attr_vmode, data.merged_attrs, data.merged_ctxattrs)
-            self._writerow(row_num if args.numbering else None, *lang_rows)
+            self._writerow(row_num + args.numbering_offset if args.numbering else None, *lang_rows)
 
     async def write_coll(self, amodel: ConcActionModel, data: CalculateCollsResult, args: SavecollArgs):
         self._sheet.title = amodel.plugin_ctx.translate('collocations')

--- a/lib/plugins/export/default_xml.py
+++ b/lib/plugins/export/default_xml.py
@@ -314,7 +314,8 @@ class XMLExport(AbstractExport):
             self._document.add_multilang_line(lang_rows, self._corpnames, line_num)
 
     async def write_conc(self, amodel: ConcActionModel, data: KwicPageData, args: SaveConcArgs):
-        self._document = ConcDocument()
+        if self._document is None:
+            self._document = ConcDocument()
         aligned_corpora = [
             amodel.corp,
             *[(await amodel.cf.get_corpus(c)) for c in amodel.args.align if c],
@@ -345,7 +346,7 @@ class XMLExport(AbstractExport):
             if 'Align' in line:
                 lang_rows += self._process_lang(
                     line['Align'], left_key, kwic_key, right_key, False, amodel.args.attr_vmode, data.merged_attrs, data.merged_ctxattrs)
-            self._writerow(row_num if args.numbering else None, *lang_rows)
+            self._writerow(row_num + args.numbering_offset if args.numbering else None, *lang_rows)
 
     async def write_coll(self, amodel: ConcActionModel, data: CalculateCollsResult, args: SavecollArgs):
         self._document = CollDocument()

--- a/lib/plugins/export/templates/txt_conc.jinja2
+++ b/lib/plugins/export/templates/txt_conc.jinja2
@@ -20,6 +20,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 -#}
 
 {% if heading -%}
+## KWIC lines:
+
 # Corpus: {{ human_corpname }}
 {% if usesubcorp %}# Subcorpus: {{ usesubcorp }}{% endif -%}
 # Hits: {{ concsize | formatnumber }}
@@ -29,11 +31,9 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 # {{ desc.op }}: {{ desc.arg }} {{ desc.size | formatnumber }}
 {% endfor %}
 {% endif -%} {# END of heading -#}
-## KWIC lines:
-
 {% for line in Lines -%}
 {# main concordances -#}
-{% if numbering %}{{ loop.index }}) {% endif %}{% if num_lines_in_groups > 0 %}{{ line.linegroup }}{% endif -%}
+{% if numbering %}{{ loop.index + numbering_offset }}) {% endif %}{% if num_lines_in_groups > 0 %}{{ line.linegroup }}{% endif -%}
 {{ line.ref }} | {% if align_kwic %}{{ line.leftspace }}{% endif -%}
 {{ line.Left|rejectattr("class", "equalto", "strc")|map(attribute="str")|join(" ") }} <{{ line.Kwic|map(attribute="str")|join(" ") }}> {% if align_kwic %}{{kwic_spaces[loop.index-1]}}{% endif %}{{ line.Right|rejectattr("class", "equalto", "strc")|map(attribute="str")|join(" ") -}}
 {% if align_kwic %}{{ line.rightspace }}{% endif %}

--- a/lib/views/concordance.py
+++ b/lib/views/concordance.py
@@ -1225,6 +1225,7 @@ class SaveConcArgs:
     saveformat: str = 'txt'
     heading: int = 0
     numbering: int = 0
+    numbering_offset: int = 0
     align_kwic: int = 0
     from_line: int = 0
     to_line: IntOpt = -1
@@ -1251,6 +1252,9 @@ def _get_ipm_base_set_desc(corp: AbstractKCorpus, contains_within, translate: Ca
 @http_action(
     access_level=2, action_model=ConcActionModel, mapped_args=SaveConcArgs, return_type='plain')
 async def saveconc(amodel: ConcActionModel, req: KRequest[SaveConcArgs], resp: KResponse):
+    def mkfilename(suffix):
+        return f'{amodel.args.corpname}-concordance.{suffix}'
+
     try:
         corpus_info = await amodel.get_corpus_info(amodel.args.corpname)
         amodel.apply_viewmode(corpus_info.sentence_struct)
@@ -1261,34 +1265,17 @@ async def saveconc(amodel: ConcActionModel, req: KRequest[SaveConcArgs], resp: K
         amodel.apply_linegroups(conc)
         kwic = Kwic(amodel.corp, conc)
         conc.switch_aligned(os.path.basename(amodel.args.corpname))
-        from_line = int(req.mapped_args.from_line)
-        to_line = conc.size() if req.mapped_args.to_line < 0 else min(req.mapped_args.to_line, conc.size())
 
-        kwic_args = KwicPageArgs(asdict(amodel.args), base_attr=amodel.BASE_ATTR)
-        kwic_args.speech_attr = await amodel.get_speech_segment()
-        kwic_args.fromp = 1
-        kwic_args.pagesize = to_line - (from_line - 1)
-        kwic_args.line_offset = (from_line - 1)
-        kwic_args.labelmap = {}
-        kwic_args.alignlist = [(await amodel.cf.get_corpus(c)) for c in amodel.args.align if c]
-        kwic_args.leftctx = amodel.args.leftctx
-        kwic_args.rightctx = amodel.args.rightctx
-        kwic_args.structs = amodel.get_struct_opts()
-        with plugins.runtime.TOKENS_LINKING as tl:
-            kwic_args.internal_attrs = await tl.get_required_attrs(
-                amodel.plugin_ctx,
-                corpus_info.tokens_linking.providers,
-                [amodel.args.corpname] + amodel.args.align)
+        if len(amodel.args.align) == 0:
+            line_range_chunks = [(
+                int(req.mapped_args.from_line) - 1,
+                conc.size() - 1 if req.mapped_args.to_line < 0 else min(req.mapped_args.to_line, conc.size()) - 1
+            )]
+        else:
+            line_range_chunks = []
+            for i in range(req.mapped_args.from_line-1, req.mapped_args.to_line-1, 2000):
+                line_range_chunks.append((i, i+2000))
 
-        data = kwic.kwicpage(kwic_args)
-
-        maxcontext = int(amodel.corp.get_conf('MAXCONTEXT'))
-        if maxcontext:
-            for line in data.Lines:
-                if len(line["Kwic"]) > maxcontext:
-                    raise UnavailableForLegalReasons('KWIC too large')
-
-        def mkfilename(suffix): return f'{amodel.args.corpname}-concordance.{suffix}'
         with plugins.runtime.EXPORT as export:
             writer = export.load_plugin(req.mapped_args.saveformat, req.locale)
 
@@ -1297,8 +1284,35 @@ async def saveconc(amodel: ConcActionModel, req: KRequest[SaveConcArgs], resp: K
                 'Content-Disposition',
                 f'attachment; filename="{mkfilename(req.mapped_args.saveformat)}"')
 
-            if len(data.Lines) > 0:
-                await writer.write_conc(amodel, data, req.mapped_args)
+            for from_line, to_line in line_range_chunks:
+                if from_line > 0:
+                    req.mapped_args.heading = 0
+                req.mapped_args.numbering_offset = from_line
+                kwic_args = KwicPageArgs(asdict(amodel.args), base_attr=amodel.BASE_ATTR)
+                kwic_args.speech_attr = await amodel.get_speech_segment()
+                kwic_args.fromp = 1
+                kwic_args.pagesize = to_line - from_line
+                kwic_args.line_offset = from_line
+                kwic_args.labelmap = {}
+                kwic_args.alignlist = [(await amodel.cf.get_corpus(c)) for c in amodel.args.align if c]
+                kwic_args.leftctx = amodel.args.leftctx
+                kwic_args.rightctx = amodel.args.rightctx
+                kwic_args.structs = amodel.get_struct_opts()
+                with plugins.runtime.TOKENS_LINKING as tl:
+                    kwic_args.internal_attrs = await tl.get_required_attrs(
+                        amodel.plugin_ctx,
+                        corpus_info.tokens_linking.providers,
+                        [amodel.args.corpname] + amodel.args.align)
+
+                data = kwic.kwicpage(kwic_args)
+
+                maxcontext = int(amodel.corp.get_conf('MAXCONTEXT'))
+                if maxcontext:
+                    for line in data.Lines:
+                        if len(line["Kwic"]) > maxcontext:
+                            raise UnavailableForLegalReasons('KWIC too large')
+                    if len(data.Lines) > 0:
+                        await writer.write_conc(amodel, data, req.mapped_args)
             output = writer.raw_content()
         return output
 


### PR DESCRIPTION
In case user wants to save a parallel concordance over 2000 lines (which is an observer "ok enough" value), we generate chunks of kwiclines and write the result piece by piece as otherwise, server often fails to perform the action with hard to handle errors)